### PR TITLE
docs: standardize and simplify how data-dict is described

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # data-dict.yaml
 
-`data-dict.yaml` is a YAML-based data dictionary specification and validator. It describes collections of related tables — their columns, types, constraints, relationships, and domain vocabulary — and is designed to be co-written by humans and AI agents. The main deliverable is a CLI tool that validates data dictionary YAML files against the spec.
+`data-dict.yaml` is a lightweight, YAML-based data dictionary specification for describing collections of related tables — their columns, types, constraints, relationships, and domain vocabulary. The main deliverable is a CLI tool that validates data dictionary YAML files against the spec.
 
 The repo contains:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # `data-dict.yaml`
 
-`data-dict.yaml` is a lightweight, YAML-based data dictionary specification. It
-describes a collection of related tables — their columns, types, constraints,
-relationships, and the domain vocabulary you need to understand them — in a
-single file that humans and AI agents can co-author and keep in sync with your
-data.
+`data-dict.yaml` is a lightweight, YAML-based data dictionary specification for
+describing collections of related tables — their columns, types, constraints,
+relationships, and domain vocabulary.
 
 **Full documentation, including the detailed specification, lives at
 [data-dict.tidyverse.org](https://data-dict.tidyverse.org).**

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -9,9 +9,9 @@ website:
   site-url: https://data-dict.tidyverse.org
   repo-url: https://github.com/tidyverse/data-dict
   description: >
-    A YAML-based data dictionary specification for describing collections of
-    related tables — their columns, types, constraints, relationships, and
-    domain vocabulary.
+    A lightweight, YAML-based data dictionary specification for describing
+    collections of related tables — their columns, types, constraints,
+    relationships, and domain vocabulary.
   llms-txt: true
   navbar:
     left:

--- a/site/index.md
+++ b/site/index.md
@@ -2,7 +2,7 @@
 title: "data-dict.yaml"
 ---
 
-`data-dict.yaml` is a data dictionary specification that describes a collection of related tables: their contents, constraints, connections, and the specialised vocabulary you need to understand them. It is designed to be a living document, co-written by humans and agents, that tracks your understanding of a dataset as it evolves.
+`data-dict.yaml` is a data dictionary specification that describes a collection of related tables: their contents, constraints, connections, and the specialised vocabulary you need to understand them. It is designed to be a living document that tracks your understanding of a dataset as it evolves.
 
 `data-dict.yaml` is designed to be lightweight. It doesn't attempt to precisely describe every possible type of metadata in a machine-readable way. Instead it focuses on precisely recording the most important components, leaving the remainder to plain text fields that require a human or agent to interpret. This means that `data-dict.yaml` doesn't itself do **data cleaning**, but it is a useful complement to tools that do.
 


### PR DESCRIPTION
I think that data-dict is potentially powerful enough whether or not AI even existed and (my opinion), referencing AI in the "tagline" undersells its potential impact and utility. It never needed AI, as all these things that data-dict is trying to do help with data quality and documentation *full stop*. Regardless of whether AI is involved or not.

Also, including AI in the tagline can be interpreted as a tool where you need to use AI, and I know that's not true.

Of course, if AI/agents is an important selling point for you and your plans, you can definitely close this PR.