### PR TITLE
Validate foreign keys

### DIFF
--- a/crates/data-dict-parquet/Cargo.toml
+++ b/crates/data-dict-parquet/Cargo.toml
@@ -23,3 +23,7 @@ criterion = "0.5"
 [[bench]]
 name = "uniqueness"
 harness = false
+
+[[bench]]
+name = "foreign_key"
+harness = false

--- a/crates/data-dict-parquet/benches/foreign_key.rs
+++ b/crates/data-dict-parquet/benches/foreign_key.rs
@@ -1,0 +1,115 @@
+//! Foreign-key (D05) benchmarks over generated parent/child Parquet fixtures.
+//!
+//! Row count is configurable with `DDP_BENCH_ROWS` (default 3,000,000). Both
+//! fixtures hold the same `rows` distinct keys, and every child row references a
+//! key that exists — the all-valid case, which is the check's worst case since
+//! no probe can short-circuit. `int` exercises the scalar (`i64`) key path,
+//! `string` the byte-key path. Fixtures are written once to the temp dir and
+//! reused across runs.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use data_dict_parquet::{ForeignKeyCheck, foreign_key_stats};
+use parquet::basic::{Compression, Repetition, Type as PhysicalType};
+use parquet::data_type::{ByteArray, ByteArrayType, Int64Type};
+use parquet::file::properties::WriterProperties;
+use parquet::file::writer::SerializedFileWriter;
+use parquet::schema::types::Type;
+
+const ROWS_PER_GROUP: usize = 1_000_000;
+
+fn rows() -> usize {
+    std::env::var("DDP_BENCH_ROWS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3_000_000)
+}
+
+/// A two-column table (`id`, `code`) of `rows` distinct keys, `id[i] == i`. The
+/// parent and child fixtures share this shape, so a child key always resolves.
+fn fixture(name: &str, rows: usize) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("ddp_bench_fk_{name}_{rows}.parquet"));
+    if path.exists() {
+        return path;
+    }
+    let schema = Arc::new(
+        Type::group_type_builder("schema")
+            .with_fields(vec![
+                Arc::new(field("id", PhysicalType::INT64)),
+                Arc::new(field("code", PhysicalType::BYTE_ARRAY)),
+            ])
+            .build()
+            .unwrap(),
+    );
+    let props = Arc::new(
+        WriterProperties::builder()
+            .set_compression(Compression::SNAPPY)
+            .build(),
+    );
+    let mut writer =
+        SerializedFileWriter::new(File::create(&path).unwrap(), schema, props).unwrap();
+    let mut written = 0;
+    while written < rows {
+        let n = ROWS_PER_GROUP.min(rows - written);
+        let ids: Vec<i64> = (0..n).map(|i| (written + i) as i64).collect();
+        let code: Vec<ByteArray> = ids
+            .iter()
+            .map(|&i| ByteArray::from(format!("CODE-{i:08}").into_bytes()))
+            .collect();
+        let mut group = writer.next_row_group().unwrap();
+        let mut col = group.next_column().unwrap().unwrap();
+        col.typed::<Int64Type>()
+            .write_batch(&ids, None, None)
+            .unwrap();
+        col.close().unwrap();
+        let mut col = group.next_column().unwrap().unwrap();
+        col.typed::<ByteArrayType>()
+            .write_batch(&code, None, None)
+            .unwrap();
+        col.close().unwrap();
+        group.close().unwrap();
+        written += n;
+    }
+    writer.close().unwrap();
+    path
+}
+
+fn field(name: &str, physical: PhysicalType) -> Type {
+    Type::primitive_type_builder(name, physical)
+        .with_repetition(Repetition::REQUIRED)
+        .build()
+        .unwrap()
+}
+
+fn check(child: &Path, parent: &Path, column: &str) -> Vec<ForeignKeyCheck> {
+    vec![ForeignKeyCheck {
+        child_path: child.to_path_buf(),
+        child_column: column.to_string(),
+        parent_path: parent.to_path_buf(),
+        parent_column: column.to_string(),
+    }]
+}
+
+fn bench(c: &mut Criterion) {
+    let n = rows();
+    let parent = fixture("parent", n);
+    let child = fixture("child", n);
+    let run = |checks: &[ForeignKeyCheck]| foreign_key_stats(checks, 5).unwrap();
+
+    let mut group = c.benchmark_group("foreign_key");
+    group
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500));
+    group.bench_function("int", |b| b.iter(|| run(&check(&child, &parent, "id"))));
+    group.bench_function("string", |b| {
+        b.iter(|| run(&check(&child, &parent, "code")))
+    });
+    group.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/crates/data-dict-parquet/src/column_scan.rs
+++ b/crates/data-dict-parquet/src/column_scan.rs
@@ -1,0 +1,426 @@
+//! Shared column-reading primitives for the value-scanning data checks.
+//!
+//! A streaming, column-projected batch reader that decodes one column's values
+//! row-aligned (nulls included), plus the value canonicalization and the
+//! arena-backed byte-key set the uniqueness (D02) and foreign-key (D05) checks
+//! both build on. See the "comparable types" section of `site/validation.md`
+//! for why values are normalized the way they are.
+
+use std::fs::File;
+
+use hashbrown::{DefaultHashBuilder, HashTable};
+use parquet::basic::Type as PhysicalType;
+use parquet::column::reader::ColumnReader;
+use parquet::data_type::ByteArray;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use parquet::schema::types::SchemaDescPtr;
+use std::hash::BuildHasher;
+
+use crate::ParquetError;
+use crate::metadata::{Comparability, Normalization, uniqueness_comparability};
+
+/// Rows decoded per `read_records` call. Large enough to amortise per-call
+/// overhead, small enough that a batch of every scanned column stays in cache.
+pub(crate) const BATCH_ROWS: usize = 8192;
+
+/// A column scanned for a check, identified by its leaf index.
+pub(crate) struct PlannedColumn {
+    pub(crate) name: String,
+    pub(crate) leaf: usize,
+    pub(crate) physical: PhysicalType,
+    pub(crate) max_def: i16,
+    pub(crate) normalize: Normalization,
+}
+
+impl PlannedColumn {
+    /// Whether the column's values are hashed as a single `i64` scalar (as
+    /// opposed to a variable-length byte string).
+    pub(crate) fn is_scalar(&self) -> bool {
+        !matches!(
+            self.physical,
+            PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY | PhysicalType::INT96
+        )
+    }
+}
+
+/// Resolve a column name to its leaf position and reading plan.
+pub(crate) fn plan_column(
+    descr: &SchemaDescPtr,
+    name: &str,
+) -> Result<PlannedColumn, ParquetError> {
+    let leaf = (0..descr.num_columns())
+        .find(|&i| descr.column(i).name() == name)
+        .ok_or_else(|| ParquetError::General(format!("Column not found: {name}")))?;
+    let column = descr.column(leaf);
+    let normalize = match uniqueness_comparability(column.self_type()) {
+        Comparability::Comparable(normalize) => normalize,
+        Comparability::Incomparable(_) => Normalization::None,
+    };
+    Ok(PlannedColumn {
+        name: name.to_string(),
+        leaf,
+        physical: column.physical_type(),
+        max_def: column.max_def_level(),
+        normalize,
+    })
+}
+
+/// The barrier reason if the column's type can't be compared (see
+/// [`uniqueness_comparability`]), else `None`.
+pub(crate) fn column_barrier(descr: &SchemaDescPtr, leaf: usize) -> Option<&'static str> {
+    match uniqueness_comparability(descr.column(leaf).self_type()) {
+        Comparability::Incomparable(reason) => Some(reason),
+        Comparability::Comparable(_) => None,
+    }
+}
+
+/// One column's values for a batch of rows, decoded row-aligned (nulls included)
+/// into either scalar `i64`s or byte strings. Byte values keep the [`ByteArray`]
+/// handles the reader produced, so [`ColumnBatch::bytes`] is a zero-copy slice
+/// into Parquet's decoded page (or dictionary) buffer rather than a re-copy.
+///
+/// `null` is empty when the column is `REQUIRED` (it can't contain nulls), which
+/// skips a per-batch mask allocation on the common path.
+pub(crate) enum ColumnBatch {
+    Scalar {
+        values: Vec<i64>,
+        null: Vec<bool>,
+    },
+    Bytes {
+        values: Vec<ByteArray>,
+        null: Vec<bool>,
+    },
+}
+
+impl ColumnBatch {
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            ColumnBatch::Scalar { values, .. } => values.len(),
+            ColumnBatch::Bytes { values, .. } => values.len(),
+        }
+    }
+
+    pub(crate) fn is_null(&self, row: usize) -> bool {
+        match self {
+            ColumnBatch::Scalar { null, .. } | ColumnBatch::Bytes { null, .. } => {
+                !null.is_empty() && null[row]
+            }
+        }
+    }
+
+    pub(crate) fn scalar(&self, row: usize) -> i64 {
+        match self {
+            ColumnBatch::Scalar { values, .. } => values[row],
+            ColumnBatch::Bytes { .. } => unreachable!("scalar read of a byte column"),
+        }
+    }
+
+    pub(crate) fn bytes(&self, row: usize) -> &[u8] {
+        match self {
+            ColumnBatch::Bytes { values, .. } => values[row].data(),
+            ColumnBatch::Scalar { .. } => unreachable!("byte read of a scalar column"),
+        }
+    }
+}
+
+/// Stream a single column across every row group, invoking `visit` once per
+/// non-null value with `(batch, row within batch, 0-based row number)`.
+pub(crate) fn scan_column<F>(
+    reader: &SerializedFileReader<File>,
+    column: &PlannedColumn,
+    mut visit: F,
+) -> Result<(), ParquetError>
+where
+    F: FnMut(&ColumnBatch, usize, usize),
+{
+    let mut row_offset = 0usize;
+    for group in 0..reader.num_row_groups() {
+        let row_group = reader.get_row_group(group)?;
+        let mut column_reader = row_group.get_column_reader(column.leaf)?;
+        loop {
+            let batch = read_batch(&mut column_reader, column)?;
+            let rows = batch.len();
+            if rows == 0 {
+                break;
+            }
+            for row in 0..rows {
+                if !batch.is_null(row) {
+                    visit(&batch, row, row_offset + row);
+                }
+            }
+            row_offset += rows;
+        }
+    }
+    Ok(())
+}
+
+/// Read up to [`BATCH_ROWS`] rows from one column, expanding nulls back into
+/// their row positions so every column in a batch shares the same row indices.
+pub(crate) fn read_batch(
+    reader: &mut ColumnReader,
+    column: &PlannedColumn,
+) -> Result<ColumnBatch, ParquetError> {
+    let max_def = column.max_def;
+    macro_rules! scalar {
+        ($variant:path, $map:expr) => {{
+            let $variant(ref mut typed) = *reader else {
+                return Err(physical_mismatch(column));
+            };
+            let mut def = Vec::new();
+            let mut raw = Vec::new();
+            let (records, _, _) = typed.read_records(BATCH_ROWS, Some(&mut def), None, &mut raw)?;
+            let mut values = vec![0i64; records];
+            let mut null = Vec::new();
+            if max_def == 0 {
+                for (out, value) in values.iter_mut().zip(&raw) {
+                    *out = $map(value);
+                }
+            } else {
+                null = vec![false; records];
+                let mut cursor = 0;
+                for row in 0..records {
+                    if def[row] == max_def {
+                        values[row] = $map(&raw[cursor]);
+                        cursor += 1;
+                    } else {
+                        null[row] = true;
+                    }
+                }
+            }
+            Ok(ColumnBatch::Scalar { values, null })
+        }};
+    }
+    // The rare `FixedLenByteArray`/`Int96` cases must convert each value into an
+    // owned `ByteArray`; `BYTE_ARRAY` (below) skips even that, handing the decoded
+    // vector straight through.
+    macro_rules! bytes_converted {
+        ($variant:path, $conv:expr) => {{
+            let $variant(ref mut typed) = *reader else {
+                return Err(physical_mismatch(column));
+            };
+            let mut def = Vec::new();
+            let mut raw = Vec::new();
+            let (records, _, _) = typed.read_records(BATCH_ROWS, Some(&mut def), None, &mut raw)?;
+            let values = raw.into_iter().map($conv).collect();
+            Ok(expand_bytes(values, &def, max_def, records))
+        }};
+    }
+
+    match column.physical {
+        PhysicalType::BOOLEAN => scalar!(ColumnReader::BoolColumnReader, |v: &bool| *v as i64),
+        PhysicalType::INT32 => scalar!(ColumnReader::Int32ColumnReader, |v: &i32| *v as i64),
+        PhysicalType::INT64 => scalar!(ColumnReader::Int64ColumnReader, |v: &i64| *v),
+        PhysicalType::FLOAT => scalar!(ColumnReader::FloatColumnReader, float_bits),
+        PhysicalType::DOUBLE => scalar!(ColumnReader::DoubleColumnReader, double_bits),
+        PhysicalType::BYTE_ARRAY => {
+            let ColumnReader::ByteArrayColumnReader(ref mut typed) = *reader else {
+                return Err(physical_mismatch(column));
+            };
+            let mut def = Vec::new();
+            let mut raw = Vec::new();
+            let (records, _, _) = typed.read_records(BATCH_ROWS, Some(&mut def), None, &mut raw)?;
+            Ok(expand_bytes(raw, &def, max_def, records))
+        }
+        PhysicalType::FIXED_LEN_BYTE_ARRAY => {
+            bytes_converted!(ColumnReader::FixedLenByteArrayColumnReader, fixed_len_owned)
+        }
+        PhysicalType::INT96 => bytes_converted!(ColumnReader::Int96ColumnReader, int96_owned),
+    }
+}
+
+/// Place non-null byte values back at their row positions, moving (never cloning)
+/// each value. With no nulls the decoded vector is already row-aligned, so it is
+/// used as-is.
+fn expand_bytes(nonnull: Vec<ByteArray>, def: &[i16], max_def: i16, records: usize) -> ColumnBatch {
+    if max_def == 0 {
+        return ColumnBatch::Bytes {
+            values: nonnull,
+            null: Vec::new(),
+        };
+    }
+    let mut values = Vec::with_capacity(records);
+    let mut null = vec![false; records];
+    let mut nonnull = nonnull.into_iter();
+    for row in 0..records {
+        if def[row] == max_def {
+            values.push(nonnull.next().expect("a value for each defined row"));
+        } else {
+            null[row] = true;
+            values.push(ByteArray::default());
+        }
+    }
+    ColumnBatch::Bytes { values, null }
+}
+
+/// Hash a float by value, not by bits: `-0.0`/`+0.0` collapse to one key and
+/// every NaN bit pattern collapses to one key, so logically-equal floats compare
+/// equal (see the "comparable types" section of `site/validation.md`).
+fn float_bits(value: &f32) -> i64 {
+    let bits = if *value == 0.0 {
+        0
+    } else if value.is_nan() {
+        f32::NAN.to_bits()
+    } else {
+        value.to_bits()
+    };
+    bits as i64
+}
+
+fn double_bits(value: &f64) -> i64 {
+    let bits = if *value == 0.0 {
+        0
+    } else if value.is_nan() {
+        f64::NAN.to_bits()
+    } else {
+        value.to_bits()
+    };
+    bits as i64
+}
+
+/// Apply a byte column's [`Normalization`] before hashing. Only decimals need it
+/// (trimming redundant leading sign bytes); everything else is returned as-is.
+pub(crate) fn normalize_bytes(bytes: &[u8], normalize: Normalization) -> &[u8] {
+    match normalize {
+        Normalization::DecimalBytes => normalize_decimal(bytes),
+        _ => bytes,
+    }
+}
+
+/// Canonical minimal two's-complement form: drop redundant leading sign-extension
+/// bytes so equal decimal values encoded at different byte lengths compare equal.
+/// Keeps at least one byte.
+fn normalize_decimal(bytes: &[u8]) -> &[u8] {
+    let mut start = 0;
+    while start + 1 < bytes.len() {
+        let sign = bytes[start];
+        let next_high = bytes[start + 1] & 0x80;
+        // A leading byte is redundant only when the next byte carries the same
+        // sign bit: 0x00 before a positive byte, or 0xFF before a negative one.
+        let redundant = (sign == 0x00 && next_high == 0) || (sign == 0xFF && next_high == 0x80);
+        if !redundant {
+            break;
+        }
+        start += 1;
+    }
+    &bytes[start..]
+}
+
+/// A human-readable form of one value, for sampling in a diagnostic.
+pub(crate) fn display_value(batch: &ColumnBatch, row: usize, column: &PlannedColumn) -> String {
+    match batch {
+        ColumnBatch::Scalar { .. } => {
+            let bits = batch.scalar(row);
+            match column.physical {
+                PhysicalType::BOOLEAN => (bits != 0).to_string(),
+                PhysicalType::FLOAT => f32::from_bits(bits as u32).to_string(),
+                PhysicalType::DOUBLE => f64::from_bits(bits as u64).to_string(),
+                _ => bits.to_string(),
+            }
+        }
+        ColumnBatch::Bytes { .. } => {
+            let bytes = batch.bytes(row);
+            match std::str::from_utf8(bytes) {
+                Ok(text) => text.to_string(),
+                Err(_) => bytes.iter().map(|b| format!("{b:02x}")).collect(),
+            }
+        }
+    }
+}
+
+fn fixed_len_owned(value: parquet::data_type::FixedLenByteArray) -> ByteArray {
+    ByteArray::from(value)
+}
+
+fn int96_owned(value: parquet::data_type::Int96) -> ByteArray {
+    // Identify the value by the raw bytes of its three words. Byte order only
+    // has to be consistent within a run, which it is.
+    let bytes: Vec<u8> = value.data().iter().flat_map(|w| w.to_le_bytes()).collect();
+    ByteArray::from(bytes)
+}
+
+fn physical_mismatch(column: &PlannedColumn) -> ParquetError {
+    ParquetError::General(format!(
+        "Column reader type does not match physical type {:?}",
+        column.physical
+    ))
+}
+
+/// A set of byte-string keys packed into one arena so distinct keys cost an
+/// amortised append, not an allocation each. Entries reference the arena by
+/// `(chunk, offset, length)`, and a single hash probe both tests membership and,
+/// when absent, positions the insertion.
+#[derive(Default)]
+pub(crate) struct ByteKeys {
+    arena: Arena,
+    table: HashTable<KeyRef>,
+    hasher: DefaultHashBuilder,
+}
+
+/// A key's location in the arena: `(chunk, offset within chunk, length)`.
+type KeyRef = (u32, u32, u32);
+
+impl ByteKeys {
+    pub(crate) fn with_capacity(rows: usize) -> Self {
+        ByteKeys {
+            arena: Arena::default(),
+            table: HashTable::with_capacity(rows),
+            hasher: DefaultHashBuilder::default(),
+        }
+    }
+
+    /// Insert `key`, returning `true` if it was new (i.e. not already present).
+    pub(crate) fn insert(&mut self, key: &[u8]) -> bool {
+        let Self {
+            arena,
+            table,
+            hasher,
+        } = self;
+        let hash = hasher.hash_one(key);
+        if table.find(hash, |&r| arena.get(r) == key).is_some() {
+            return false;
+        }
+        let entry = arena.push(key);
+        table.insert_unique(hash, entry, |&r| hasher.hash_one(arena.get(r)));
+        true
+    }
+
+    /// Whether `key` is present, without inserting it.
+    pub(crate) fn contains(&self, key: &[u8]) -> bool {
+        let hash = self.hasher.hash_one(key);
+        self.table
+            .find(hash, |&r| self.arena.get(r) == key)
+            .is_some()
+    }
+}
+
+/// Append-only byte store backed by fixed-size chunks. Existing chunks are never
+/// reallocated, so growth is incremental — there is no transient doubling spike
+/// as with one growing `Vec`, and no need to estimate the total size up front.
+#[derive(Default)]
+struct Arena {
+    chunks: Vec<Vec<u8>>,
+}
+
+impl Arena {
+    const CHUNK: usize = 4 * 1024 * 1024;
+
+    fn push(&mut self, key: &[u8]) -> KeyRef {
+        let fits = self
+            .chunks
+            .last()
+            .is_some_and(|chunk| chunk.capacity() - chunk.len() >= key.len());
+        if !fits {
+            self.chunks
+                .push(Vec::with_capacity(key.len().max(Self::CHUNK)));
+        }
+        let chunk = self.chunks.len() as u32 - 1;
+        let buffer = self.chunks.last_mut().unwrap();
+        let offset = buffer.len() as u32;
+        buffer.extend_from_slice(key);
+        (chunk, offset, key.len() as u32)
+    }
+
+    fn get(&self, (chunk, offset, len): KeyRef) -> &[u8] {
+        &self.chunks[chunk as usize][offset as usize..offset as usize + len as usize]
+    }
+}

--- a/crates/data-dict-parquet/src/foreign_key.rs
+++ b/crates/data-dict-parquet/src/foreign_key.rs
@@ -1,0 +1,156 @@
+//! Foreign-key referential integrity (D05/D06): every non-null value in a
+//! child column must appear in the parent's primary-key column.
+//!
+//! Each check builds a set of the parent column's values in one streaming pass,
+//! then streams the child column probing membership. Nulls are exempt on both
+//! sides (a null foreign key references nothing). Values are compared by the same
+//! normalized form as the uniqueness check (D02), so both columns must use a
+//! [comparable type](../metadata/fn.uniqueness_comparability.html); if either
+//! can't be compared the check is skipped and reported as D06.
+
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+use hashbrown::HashSet;
+use parquet::file::reader::{FileReader, SerializedFileReader};
+use rayon::prelude::*;
+
+use crate::ParquetError;
+use crate::column_scan::{
+    ByteKeys, ColumnBatch, PlannedColumn, column_barrier, display_value, normalize_bytes,
+    plan_column, scan_column,
+};
+
+/// One foreign-key check: the child column's values must all appear in the
+/// parent column. The two may live in the same file (a self-join) or different
+/// files.
+#[derive(Clone)]
+pub struct ForeignKeyCheck {
+    pub child_path: PathBuf,
+    pub child_column: String,
+    pub parent_path: PathBuf,
+    pub parent_column: String,
+}
+
+/// The outcome of a [`ForeignKeyCheck`].
+pub enum ForeignKeyResult {
+    /// The child or parent column uses a type whose values can't be compared, so
+    /// the reference was not checked (D06). `reason` is a barrier slug (e.g.
+    /// `json`).
+    NotVerified { reason: &'static str },
+    /// The reference was checked; `orphan_count == 0` means it holds.
+    Checked(ForeignKeyStats),
+}
+
+/// Values found in the child column that are absent from the parent column.
+/// `orphan_rows`/`orphan_values` sample the first few (1-based rows, distinct
+/// values); `orphan_count` is the total.
+#[derive(Default)]
+pub struct ForeignKeyStats {
+    pub orphan_count: usize,
+    pub orphan_rows: Vec<usize>,
+    pub orphan_values: Vec<String>,
+}
+
+/// Run every foreign-key check in parallel, each reading only its two columns.
+pub fn foreign_key_stats(
+    checks: &[ForeignKeyCheck],
+    sample_limit: usize,
+) -> Result<Vec<ForeignKeyResult>, ParquetError> {
+    checks
+        .par_iter()
+        .map(|check| check_foreign_key(check, sample_limit))
+        .collect()
+}
+
+fn open(path: &Path) -> Result<SerializedFileReader<File>, ParquetError> {
+    let file =
+        File::open(path).map_err(|e| ParquetError::General(format!("Cannot open file: {e}")))?;
+    SerializedFileReader::new(file)
+}
+
+fn check_foreign_key(
+    check: &ForeignKeyCheck,
+    sample_limit: usize,
+) -> Result<ForeignKeyResult, ParquetError> {
+    let parent_reader = open(&check.parent_path)?;
+    let parent_descr = parent_reader.metadata().file_metadata().schema_descr_ptr();
+    let parent_col = plan_column(&parent_descr, &check.parent_column)?;
+    if let Some(reason) = column_barrier(&parent_descr, parent_col.leaf) {
+        return Ok(ForeignKeyResult::NotVerified { reason });
+    }
+
+    let child_reader = open(&check.child_path)?;
+    let child_descr = child_reader.metadata().file_metadata().schema_descr_ptr();
+    let child_col = plan_column(&child_descr, &check.child_column)?;
+    if let Some(reason) = column_barrier(&child_descr, child_col.leaf) {
+        return Ok(ForeignKeyResult::NotVerified { reason });
+    }
+
+    let parent_rows = parent_reader.metadata().file_metadata().num_rows().max(0) as usize;
+    let mut seen = KeySet::with_capacity(&parent_col, parent_rows);
+    scan_column(&parent_reader, &parent_col, |batch, row, _| {
+        seen.insert(batch, row, &parent_col);
+    })?;
+
+    let mut stats = ForeignKeyStats::default();
+    let mut distinct: HashSet<String> = HashSet::new();
+    scan_column(&child_reader, &child_col, |batch, row, absolute| {
+        if seen.contains(batch, row, &child_col) {
+            return;
+        }
+        stats.orphan_count += 1;
+        if stats.orphan_rows.len() < sample_limit {
+            stats.orphan_rows.push(absolute + 1);
+        }
+        if stats.orphan_values.len() < sample_limit {
+            let value = display_value(batch, row, &child_col);
+            if distinct.insert(value.clone()) {
+                stats.orphan_values.push(value);
+            }
+        }
+    })?;
+    Ok(ForeignKeyResult::Checked(stats))
+}
+
+/// The parent column's values, with the same fast paths as the uniqueness check:
+/// a scalar column hashes bare `i64`s, a byte column hashes its (normalized)
+/// value bytes directly. A child value of the other shape is a type mismatch and
+/// can't be found, so it's treated as absent.
+enum KeySet {
+    Scalar(HashSet<i64>),
+    Bytes(ByteKeys),
+}
+
+impl KeySet {
+    fn with_capacity(column: &PlannedColumn, rows: usize) -> Self {
+        if column.is_scalar() {
+            KeySet::Scalar(HashSet::with_capacity(rows))
+        } else {
+            KeySet::Bytes(ByteKeys::with_capacity(rows))
+        }
+    }
+
+    fn insert(&mut self, batch: &ColumnBatch, row: usize, column: &PlannedColumn) {
+        match self {
+            KeySet::Scalar(set) => {
+                set.insert(batch.scalar(row));
+            }
+            KeySet::Bytes(set) => {
+                set.insert(normalize_bytes(batch.bytes(row), column.normalize));
+            }
+        }
+    }
+
+    fn contains(&self, batch: &ColumnBatch, row: usize, column: &PlannedColumn) -> bool {
+        match self {
+            KeySet::Scalar(set) => {
+                matches!(batch, ColumnBatch::Scalar { .. }) && set.contains(&batch.scalar(row))
+            }
+            KeySet::Bytes(set) => {
+                matches!(batch, ColumnBatch::Bytes { .. })
+                    && set.contains(normalize_bytes(batch.bytes(row), column.normalize))
+            }
+        }
+    }
+}

--- a/crates/data-dict-parquet/src/lib.rs
+++ b/crates/data-dict-parquet/src/lib.rs
@@ -1,10 +1,13 @@
 //! Parquet reader for data-dict.yaml validation.
 
+mod column_scan;
 mod dictionary;
+mod foreign_key;
 mod metadata;
 mod scan;
 mod uniqueness;
 
+pub use foreign_key::{ForeignKeyCheck, ForeignKeyResult, ForeignKeyStats, foreign_key_stats};
 pub use metadata::{
     ColumnMeta, ColumnTypeInfo, column_meta, column_type_info, column_types, uniqueness_barriers,
 };

--- a/crates/data-dict-parquet/src/uniqueness.rs
+++ b/crates/data-dict-parquet/src/uniqueness.rs
@@ -1,20 +1,14 @@
 use std::fs::File;
-use std::hash::BuildHasher;
 use std::path::Path;
 
-use hashbrown::{DefaultHashBuilder, HashSet, HashTable};
-use parquet::basic::Type as PhysicalType;
-use parquet::column::reader::ColumnReader;
-use parquet::data_type::ByteArray;
+use hashbrown::HashSet;
 use parquet::file::reader::{FileReader, SerializedFileReader};
 use rayon::prelude::*;
 
 use crate::ParquetError;
-use crate::metadata::{Comparability, Normalization, uniqueness_comparability};
-
-/// Rows decoded per `read_records` call. Large enough to amortise per-call
-/// overhead, small enough that a batch of every scanned column stays in cache.
-const BATCH_ROWS: usize = 8192;
+use crate::column_scan::{
+    ByteKeys, ColumnBatch, PlannedColumn, normalize_bytes, plan_column, read_batch,
+};
 
 #[derive(Clone)]
 pub struct UniquenessCheck {
@@ -88,26 +82,6 @@ fn check_uniqueness(
     Ok(stat)
 }
 
-/// A column scanned for one or more checks, identified by its leaf index.
-struct PlannedColumn {
-    name: String,
-    leaf: usize,
-    physical: PhysicalType,
-    max_def: i16,
-    normalize: Normalization,
-}
-
-impl PlannedColumn {
-    /// Whether the column's values are hashed as a single `i64` scalar (as
-    /// opposed to a variable-length byte string).
-    fn is_scalar(&self) -> bool {
-        !matches!(
-            self.physical,
-            PhysicalType::BYTE_ARRAY | PhysicalType::FIXED_LEN_BYTE_ARRAY | PhysicalType::INT96
-        )
-    }
-}
-
 /// Resolve every column named by the check to its leaf position, de-duplicated
 /// so a column repeated within a key is read only once.
 fn plan_columns(
@@ -119,241 +93,9 @@ fn plan_columns(
         if columns.iter().any(|c| &c.name == name) {
             continue;
         }
-        let leaf = (0..descr.num_columns())
-            .find(|&i| descr.column(i).name() == name)
-            .ok_or_else(|| ParquetError::General(format!("Column not found: {name}")))?;
-        let column = descr.column(leaf);
-        let normalize = match uniqueness_comparability(column.self_type()) {
-            Comparability::Comparable(normalize) => normalize,
-            Comparability::Incomparable(_) => Normalization::None,
-        };
-        columns.push(PlannedColumn {
-            name: name.clone(),
-            leaf,
-            physical: column.physical_type(),
-            max_def: column.max_def_level(),
-            normalize,
-        });
+        columns.push(plan_column(descr, name)?);
     }
     Ok(columns)
-}
-
-/// One column's values for a batch of rows, decoded row-aligned (nulls included)
-/// into either scalar `i64`s or byte strings. Byte values keep the [`ByteArray`]
-/// handles the reader produced, so [`ColumnBatch::bytes`] is a zero-copy slice
-/// into Parquet's decoded page (or dictionary) buffer rather than a re-copy.
-///
-/// `null` is empty when the column is `REQUIRED` (it can't contain nulls), which
-/// skips a per-batch mask allocation on the common path.
-enum ColumnBatch {
-    Scalar {
-        values: Vec<i64>,
-        null: Vec<bool>,
-    },
-    Bytes {
-        values: Vec<ByteArray>,
-        null: Vec<bool>,
-    },
-}
-
-impl ColumnBatch {
-    fn len(&self) -> usize {
-        match self {
-            ColumnBatch::Scalar { values, .. } => values.len(),
-            ColumnBatch::Bytes { values, .. } => values.len(),
-        }
-    }
-
-    fn is_null(&self, row: usize) -> bool {
-        match self {
-            ColumnBatch::Scalar { null, .. } | ColumnBatch::Bytes { null, .. } => {
-                !null.is_empty() && null[row]
-            }
-        }
-    }
-
-    fn scalar(&self, row: usize) -> i64 {
-        match self {
-            ColumnBatch::Scalar { values, .. } => values[row],
-            ColumnBatch::Bytes { .. } => unreachable!("scalar read of a byte column"),
-        }
-    }
-
-    fn bytes(&self, row: usize) -> &[u8] {
-        match self {
-            ColumnBatch::Bytes { values, .. } => values[row].data(),
-            ColumnBatch::Scalar { .. } => unreachable!("byte read of a scalar column"),
-        }
-    }
-}
-
-/// Read up to [`BATCH_ROWS`] rows from one column, expanding nulls back into
-/// their row positions so every column in a batch shares the same row indices.
-fn read_batch(
-    reader: &mut ColumnReader,
-    column: &PlannedColumn,
-) -> Result<ColumnBatch, ParquetError> {
-    let max_def = column.max_def;
-    macro_rules! scalar {
-        ($variant:path, $map:expr) => {{
-            let $variant(ref mut typed) = *reader else {
-                return Err(physical_mismatch(column));
-            };
-            let mut def = Vec::new();
-            let mut raw = Vec::new();
-            let (records, _, _) = typed.read_records(BATCH_ROWS, Some(&mut def), None, &mut raw)?;
-            let mut values = vec![0i64; records];
-            let mut null = Vec::new();
-            if max_def == 0 {
-                for (out, value) in values.iter_mut().zip(&raw) {
-                    *out = $map(value);
-                }
-            } else {
-                null = vec![false; records];
-                let mut cursor = 0;
-                for row in 0..records {
-                    if def[row] == max_def {
-                        values[row] = $map(&raw[cursor]);
-                        cursor += 1;
-                    } else {
-                        null[row] = true;
-                    }
-                }
-            }
-            Ok(ColumnBatch::Scalar { values, null })
-        }};
-    }
-    // The rare `FixedLenByteArray`/`Int96` cases must convert each value into an
-    // owned `ByteArray`; `BYTE_ARRAY` (below) skips even that, handing the decoded
-    // vector straight through.
-    macro_rules! bytes_converted {
-        ($variant:path, $conv:expr) => {{
-            let $variant(ref mut typed) = *reader else {
-                return Err(physical_mismatch(column));
-            };
-            let mut def = Vec::new();
-            let mut raw = Vec::new();
-            let (records, _, _) = typed.read_records(BATCH_ROWS, Some(&mut def), None, &mut raw)?;
-            let values = raw.into_iter().map($conv).collect();
-            Ok(expand_bytes(values, &def, max_def, records))
-        }};
-    }
-
-    match column.physical {
-        PhysicalType::BOOLEAN => scalar!(ColumnReader::BoolColumnReader, |v: &bool| *v as i64),
-        PhysicalType::INT32 => scalar!(ColumnReader::Int32ColumnReader, |v: &i32| *v as i64),
-        PhysicalType::INT64 => scalar!(ColumnReader::Int64ColumnReader, |v: &i64| *v),
-        PhysicalType::FLOAT => scalar!(ColumnReader::FloatColumnReader, float_bits),
-        PhysicalType::DOUBLE => scalar!(ColumnReader::DoubleColumnReader, double_bits),
-        PhysicalType::BYTE_ARRAY => {
-            let ColumnReader::ByteArrayColumnReader(ref mut typed) = *reader else {
-                return Err(physical_mismatch(column));
-            };
-            let mut def = Vec::new();
-            let mut raw = Vec::new();
-            let (records, _, _) = typed.read_records(BATCH_ROWS, Some(&mut def), None, &mut raw)?;
-            Ok(expand_bytes(raw, &def, max_def, records))
-        }
-        PhysicalType::FIXED_LEN_BYTE_ARRAY => {
-            bytes_converted!(ColumnReader::FixedLenByteArrayColumnReader, fixed_len_owned)
-        }
-        PhysicalType::INT96 => bytes_converted!(ColumnReader::Int96ColumnReader, int96_owned),
-    }
-}
-
-/// Place non-null byte values back at their row positions, moving (never cloning)
-/// each value. With no nulls the decoded vector is already row-aligned, so it is
-/// used as-is.
-fn expand_bytes(nonnull: Vec<ByteArray>, def: &[i16], max_def: i16, records: usize) -> ColumnBatch {
-    if max_def == 0 {
-        return ColumnBatch::Bytes {
-            values: nonnull,
-            null: Vec::new(),
-        };
-    }
-    let mut values = Vec::with_capacity(records);
-    let mut null = vec![false; records];
-    let mut nonnull = nonnull.into_iter();
-    for row in 0..records {
-        if def[row] == max_def {
-            values.push(nonnull.next().expect("a value for each defined row"));
-        } else {
-            null[row] = true;
-            values.push(ByteArray::default());
-        }
-    }
-    ColumnBatch::Bytes { values, null }
-}
-
-/// Hash a float by value, not by bits: `-0.0`/`+0.0` collapse to one key and
-/// every NaN bit pattern collapses to one key, so logically-equal floats compare
-/// equal (see the "comparable types" section of `site/validation.md`).
-fn float_bits(value: &f32) -> i64 {
-    let bits = if *value == 0.0 {
-        0
-    } else if value.is_nan() {
-        f32::NAN.to_bits()
-    } else {
-        value.to_bits()
-    };
-    bits as i64
-}
-
-fn double_bits(value: &f64) -> i64 {
-    let bits = if *value == 0.0 {
-        0
-    } else if value.is_nan() {
-        f64::NAN.to_bits()
-    } else {
-        value.to_bits()
-    };
-    bits as i64
-}
-
-/// Apply a byte column's [`Normalization`] before hashing. Only decimals need it
-/// (trimming redundant leading sign bytes); everything else is returned as-is.
-fn normalize_bytes(bytes: &[u8], normalize: Normalization) -> &[u8] {
-    match normalize {
-        Normalization::DecimalBytes => normalize_decimal(bytes),
-        _ => bytes,
-    }
-}
-
-/// Canonical minimal two's-complement form: drop redundant leading sign-extension
-/// bytes so equal decimal values encoded at different byte lengths compare equal.
-/// Keeps at least one byte.
-fn normalize_decimal(bytes: &[u8]) -> &[u8] {
-    let mut start = 0;
-    while start + 1 < bytes.len() {
-        let sign = bytes[start];
-        let next_high = bytes[start + 1] & 0x80;
-        // A leading byte is redundant only when the next byte carries the same
-        // sign bit: 0x00 before a positive byte, or 0xFF before a negative one.
-        let redundant = (sign == 0x00 && next_high == 0) || (sign == 0xFF && next_high == 0x80);
-        if !redundant {
-            break;
-        }
-        start += 1;
-    }
-    &bytes[start..]
-}
-
-fn fixed_len_owned(value: parquet::data_type::FixedLenByteArray) -> ByteArray {
-    ByteArray::from(value)
-}
-
-fn int96_owned(value: parquet::data_type::Int96) -> ByteArray {
-    // Identify the value by the raw bytes of its three words. Byte order only
-    // has to be consistent within a run, which it is.
-    let bytes: Vec<u8> = value.data().iter().flat_map(|w| w.to_le_bytes()).collect();
-    ByteArray::from(bytes)
-}
-
-fn physical_mismatch(column: &PlannedColumn) -> ParquetError {
-    ParquetError::General(format!(
-        "Column reader type does not match physical type {:?}",
-        column.physical
-    ))
 }
 
 /// Per-check duplicate detector, with a fast path for each single-column shape:
@@ -473,78 +215,6 @@ impl Dedup {
                 }
             }
         }
-    }
-}
-
-/// A set of byte-string keys packed into one arena so distinct keys cost an
-/// amortised append, not an allocation each. Entries reference the arena by
-/// `(offset, length)`, and a single hash probe both tests membership and, when
-/// absent, positions the insertion.
-#[derive(Default)]
-struct ByteKeys {
-    arena: Arena,
-    table: HashTable<KeyRef>,
-    hasher: DefaultHashBuilder,
-}
-
-/// A key's location in the arena: `(chunk, offset within chunk, length)`.
-type KeyRef = (u32, u32, u32);
-
-impl ByteKeys {
-    fn with_capacity(rows: usize) -> Self {
-        ByteKeys {
-            arena: Arena::default(),
-            table: HashTable::with_capacity(rows),
-            hasher: DefaultHashBuilder::default(),
-        }
-    }
-
-    /// Insert `key`, returning `true` if it was new (i.e. not a duplicate).
-    fn insert(&mut self, key: &[u8]) -> bool {
-        let Self {
-            arena,
-            table,
-            hasher,
-        } = self;
-        let hash = hasher.hash_one(key);
-        if table.find(hash, |&r| arena.get(r) == key).is_some() {
-            return false;
-        }
-        let entry = arena.push(key);
-        table.insert_unique(hash, entry, |&r| hasher.hash_one(arena.get(r)));
-        true
-    }
-}
-
-/// Append-only byte store backed by fixed-size chunks. Existing chunks are never
-/// reallocated, so growth is incremental — there is no transient doubling spike
-/// as with one growing `Vec`, and no need to estimate the total size up front.
-#[derive(Default)]
-struct Arena {
-    chunks: Vec<Vec<u8>>,
-}
-
-impl Arena {
-    const CHUNK: usize = 4 * 1024 * 1024;
-
-    fn push(&mut self, key: &[u8]) -> KeyRef {
-        let fits = self
-            .chunks
-            .last()
-            .is_some_and(|chunk| chunk.capacity() - chunk.len() >= key.len());
-        if !fits {
-            self.chunks
-                .push(Vec::with_capacity(key.len().max(Self::CHUNK)));
-        }
-        let chunk = self.chunks.len() as u32 - 1;
-        let buffer = self.chunks.last_mut().unwrap();
-        let offset = buffer.len() as u32;
-        buffer.extend_from_slice(key);
-        (chunk, offset, key.len() as u32)
-    }
-
-    fn get(&self, (chunk, offset, len): KeyRef) -> &[u8] {
-        &self.chunks[chunk as usize][offset as usize..offset as usize + len as usize]
     }
 }
 

--- a/crates/data-dict/src/lib.rs
+++ b/crates/data-dict/src/lib.rs
@@ -12,6 +12,7 @@
 //! holds the shared [`Level`] and the `compare_dataset` driver the meta and
 //! data levels build on.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 pub mod join_expr;
@@ -42,8 +43,15 @@ pub enum Level {
     Data,
 }
 
+/// The readable data behind the selected tables, keyed by table name: the
+/// resolved parquet path and the column names present in it. Passed to the
+/// cross-table pass so it can find each table's data and skip a table (or column)
+/// that couldn't be read.
+pub(crate) type ReadTables = HashMap<String, (PathBuf, Vec<String>)>;
+
 /// The shared prologue for `validate_meta` and `validate_data`, so they differ
-/// only in the `checks` they pass.
+/// only in the passes they run: `checks` per table, then `cross` once over the
+/// tables that were read (for checks that span tables, like foreign keys).
 ///
 /// Validates the spec first and stops if it has errors. Otherwise it validates
 /// every table (or just `table`, when named), locating each table's data through
@@ -54,6 +62,7 @@ pub(crate) fn compare_dataset(
     dict_path: &Path,
     table: Option<&str>,
     checks: impl Fn(&Table, &Path, &[(String, String)], &mut ProblemSet),
+    cross: impl Fn(&DataDict, &ReadTables, &mut ProblemSet),
 ) -> ProblemSet {
     let (mut problems, doc) = match load(dict_path) {
         Ok(loaded) => loaded,
@@ -66,11 +75,15 @@ pub(crate) fn compare_dataset(
         return problems;
     };
     let base_dir = dict_path.parent().unwrap_or_else(|| Path::new(""));
+    let mut readable: ReadTables = HashMap::new();
     for table in tables {
         if let Some((parquet_path, actual)) = read_parquet(table, base_dir, &mut problems) {
             checks(table, &parquet_path, &actual, &mut problems);
+            let columns = actual.iter().map(|(name, _)| name.clone()).collect();
+            readable.insert(table.name.value.clone(), (parquet_path, columns));
         }
     }
+    cross(&dict, &readable, &mut problems);
     problems
 }
 

--- a/crates/data-dict/src/model.rs
+++ b/crates/data-dict/src/model.rs
@@ -33,6 +33,37 @@ impl DataDict {
     pub fn table(&self, name: &str) -> Option<&Table> {
         self.tables.iter().find(|t| t.name.value == name)
     }
+
+    /// The `(table, column)` a single-column foreign key points at: the
+    /// `primary_key` on the other side of a relationship whose join names `col`.
+    /// `None` if `col` is not a foreign key, or no relationship resolves it (the
+    /// S01 case). Shared by the S01 spec check and the D05/D06 data checks.
+    pub fn resolve_foreign_key(&self, table: &Table, col: &Column) -> Option<(&Table, &Column)> {
+        if !col.has(Constraint::ForeignKey) {
+            return None;
+        }
+        let table_name = table.name.value.as_str();
+        for rel in &self.relationships {
+            let Some(join) = &rel.join else { continue };
+            for conj in &join.conjuncts {
+                for (fk_side, pk_side) in [(&conj.lhs, &conj.rhs), (&conj.rhs, &conj.lhs)] {
+                    if fk_side.table != table_name || fk_side.column != col.name.value {
+                        continue;
+                    }
+                    let Some(other_tbl) = self.table(&pk_side.table) else {
+                        continue;
+                    };
+                    let Some(other_col) = other_tbl.column(&pk_side.column) else {
+                        continue;
+                    };
+                    if other_col.has(Constraint::PrimaryKey) {
+                        return Some((other_tbl, other_col));
+                    }
+                }
+            }
+        }
+        None
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/crates/data-dict/src/problem.rs
+++ b/crates/data-dict/src/problem.rs
@@ -188,6 +188,27 @@ pub enum ProblemKind {
         rows: Vec<usize>,
         values: Vec<String>,
     },
+    /// `D05` — a `foreign_key` column contains values absent from the
+    /// `primary_key` it references. `column` is the foreign-key column,
+    /// `references` names the target as `table.column`, `count` is the total, and
+    /// `rows`/`values` sample the first few offending row numbers (1-based) and
+    /// distinct values.
+    ForeignKeyNotFound {
+        column: String,
+        references: String,
+        count: usize,
+        rows: Vec<usize>,
+        values: Vec<String>,
+    },
+    /// `D06` — a `foreign_key` or the `primary_key` it references uses a type
+    /// whose values can't be compared, so the reference was not checked.
+    /// `references` names the target as `table.column`; `reason` is a barrier
+    /// slug (e.g. `json`).
+    ReferentialIntegrityNotVerified {
+        column: String,
+        references: String,
+        reason: String,
+    },
 }
 
 impl ProblemKind {
@@ -205,6 +226,8 @@ impl ProblemKind {
             ProblemKind::DuplicateValues { .. } => "D02",
             ProblemKind::UniquenessNotVerified { .. } => "D03",
             ProblemKind::ValuesOutsideEnum { .. } => "D04",
+            ProblemKind::ForeignKeyNotFound { .. } => "D05",
+            ProblemKind::ReferentialIntegrityNotVerified { .. } => "D06",
             _ => return None,
         })
     }
@@ -222,7 +245,9 @@ impl ProblemKind {
             ProblemKind::NullsInRequired { .. }
             | ProblemKind::DuplicateValues { .. }
             | ProblemKind::UniquenessNotVerified { .. }
-            | ProblemKind::ValuesOutsideEnum { .. } => Level::Data,
+            | ProblemKind::ValuesOutsideEnum { .. }
+            | ProblemKind::ForeignKeyNotFound { .. }
+            | ProblemKind::ReferentialIntegrityNotVerified { .. } => Level::Data,
             _ => return None,
         })
     }

--- a/crates/data-dict/src/validate_data.rs
+++ b/crates/data-dict/src/validate_data.rs
@@ -6,9 +6,13 @@
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
-use data_dict_parquet::{ColumnMeta, ColumnNeeds, ColumnStats, UniquenessCheck, UniquenessStats};
+use data_dict_parquet::{
+    ColumnMeta, ColumnNeeds, ColumnStats, ForeignKeyCheck, ForeignKeyResult, ForeignKeyStats,
+    UniquenessCheck, UniquenessStats,
+};
 
-use crate::model::{Column, Constraint, Table};
+use crate::ReadTables;
+use crate::model::{Column, Constraint, DataDict, Table};
 use crate::problem::{Problem, ProblemKind, ProblemSet, Severity};
 use crate::validate_meta::CheckResult;
 
@@ -23,12 +27,17 @@ const SAMPLE_LIMIT: usize = 5;
 /// below: reading the columns and pages the checks imply and reporting, for
 /// example, nulls in a required column.
 pub fn validate_data(dict_path: &Path, table: Option<&str>) -> ProblemSet {
-    crate::compare_dataset(dict_path, table, |table, parquet_path, actual, problems| {
-        crate::validate_meta::meta_issues(table, actual, problems);
-        if let Err(e) = value_issues(table, parquet_path, actual, problems) {
-            problems.push(Problem::preflight(ProblemKind::Parquet, e.to_string()));
-        }
-    })
+    crate::compare_dataset(
+        dict_path,
+        table,
+        |table, parquet_path, actual, problems| {
+            crate::validate_meta::meta_issues(table, actual, problems);
+            if let Err(e) = value_issues(table, parquet_path, actual, problems) {
+                problems.push(Problem::preflight(ProblemKind::Parquet, e.to_string()));
+            }
+        },
+        foreign_key_issues,
+    )
 }
 
 /// Run the value-level checks for the dictionary's `table` against the data,
@@ -466,6 +475,155 @@ fn uniqueness_not_verified_primary_key(
             .collect(),
         kind: ProblemKind::UniquenessNotVerified {
             columns: columns.iter().map(|col| col.name.value.clone()).collect(),
+            reason: reason.to_string(),
+        },
+    }
+}
+
+/// D05/D06 — referential integrity. Runs once over the tables that were read,
+/// checking each single-column foreign key's values against the `primary_key` it
+/// references, whose data may live in another table's source.
+fn foreign_key_issues(dict: &DataDict, readable: &ReadTables, out: &mut ProblemSet) {
+    let mut checks = Vec::new();
+    let mut targets = Vec::new();
+    for table in &dict.tables {
+        let Some((child_path, child_columns)) = readable.get(&table.name.value) else {
+            continue;
+        };
+        for col in &table.columns {
+            // A foreign key column absent from the data is already an M02; don't
+            // also fail its data read here.
+            if !col.has(Constraint::ForeignKey) || !child_columns.contains(&col.name.value) {
+                continue;
+            }
+            let Some((parent_table, parent_col)) = dict.resolve_foreign_key(table, col) else {
+                continue;
+            };
+            let Some((parent_path, parent_columns)) = readable.get(&parent_table.name.value) else {
+                continue;
+            };
+            if !parent_columns.contains(&parent_col.name.value) {
+                continue;
+            }
+            checks.push(ForeignKeyCheck {
+                child_path: child_path.clone(),
+                child_column: col.name.value.clone(),
+                parent_path: parent_path.clone(),
+                parent_column: parent_col.name.value.clone(),
+            });
+            targets.push((table, col, parent_table, parent_col));
+        }
+    }
+    if checks.is_empty() {
+        return;
+    }
+    let results = match data_dict_parquet::foreign_key_stats(&checks, SAMPLE_LIMIT) {
+        Ok(results) => results,
+        Err(e) => {
+            out.push(Problem::preflight(ProblemKind::Parquet, e.to_string()));
+            return;
+        }
+    };
+    for ((table, col, parent_table, parent_col), result) in targets.iter().zip(results) {
+        match result {
+            ForeignKeyResult::NotVerified { reason } => out.push(
+                referential_integrity_not_verified(table, col, parent_table, parent_col, reason),
+            ),
+            ForeignKeyResult::Checked(stats) if stats.orphan_count > 0 => {
+                out.push(foreign_key_not_found(
+                    table,
+                    col,
+                    parent_table,
+                    parent_col,
+                    &stats,
+                ));
+            }
+            ForeignKeyResult::Checked(_) => {}
+        }
+    }
+}
+
+fn fk_constraint_span(col: &Column) -> quarto_source_map::SourceInfo {
+    col.constraints
+        .iter()
+        .find(|constraint| constraint.value == Constraint::ForeignKey)
+        .map_or_else(
+            || col.name.span.clone(),
+            |constraint| constraint.span.clone(),
+        )
+}
+
+fn foreign_key_not_found(
+    table: &Table,
+    col: &Column,
+    parent_table: &Table,
+    parent_col: &Column,
+    stats: &ForeignKeyStats,
+) -> Problem {
+    let count = stats.orphan_count;
+    let detail = crate::problem::format_rows(&stats.orphan_rows, count);
+    let plural = if count == 1 { "" } else { "s" };
+    let sample = stats
+        .orphan_values
+        .iter()
+        .map(|value| format!("`{value}`"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let references = format!("{}.{}", parent_table.name.value, parent_col.name.value);
+    Problem {
+        code: Some("D05"),
+        severity: Severity::Error,
+        message: format!(
+            "has {count} value{plural} not found in `{references}` ({sample}; {detail})"
+        ),
+        column: None,
+        expected: Some(
+            "A foreign key's values must all appear in the primary key it references.".into(),
+        ),
+        hint: None,
+        suggestion: None,
+        context: vec![
+            table.name.span.clone(),
+            col.name.span.clone(),
+            fk_constraint_span(col),
+        ],
+        kind: ProblemKind::ForeignKeyNotFound {
+            column: col.name.value.clone(),
+            references,
+            count,
+            rows: stats.orphan_rows.clone(),
+            values: stats.orphan_values.clone(),
+        },
+    }
+}
+
+fn referential_integrity_not_verified(
+    table: &Table,
+    col: &Column,
+    parent_table: &Table,
+    parent_col: &Column,
+    reason: &str,
+) -> Problem {
+    let references = format!("{}.{}", parent_table.name.value, parent_col.name.value);
+    Problem {
+        code: Some("D06"),
+        severity: Severity::Warning,
+        message: format!(
+            "can't be verified against `{references}`: {} values aren't comparable",
+            barrier_phrase(reason)
+        ),
+        column: None,
+        expected: Some("Referential integrity can only be verified for comparable types.".into()),
+        hint: None,
+        suggestion: None,
+        context: vec![
+            table.name.span.clone(),
+            col.name.span.clone(),
+            fk_constraint_span(col),
+        ],
+        kind: ProblemKind::ReferentialIntegrityNotVerified {
+            column: col.name.value.clone(),
+            references,
             reason: reason.to_string(),
         },
     }

--- a/crates/data-dict/src/validate_meta.rs
+++ b/crates/data-dict/src/validate_meta.rs
@@ -27,9 +27,14 @@ pub(crate) enum CheckResult {
 /// data the dictionary does not describe. Values are never read; see
 /// [`crate::validate_data::validate_data`] for the level that does.
 pub fn validate_meta(dict_path: &Path, table: Option<&str>) -> ProblemSet {
-    crate::compare_dataset(dict_path, table, |table, _parquet, actual, problems| {
-        meta_issues(table, actual, problems);
-    })
+    crate::compare_dataset(
+        dict_path,
+        table,
+        |table, _parquet, actual, problems| {
+            meta_issues(table, actual, problems);
+        },
+        |_dict, _readable, _problems| {},
+    )
 }
 
 /// Compare the dictionary's `table` against the actual column types read from

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -307,28 +307,7 @@ fn validate_s01_foreign_key(dict: &DataDict, table: &Table, col: &Column, out: &
     if !col.has(ForeignKey) {
         return;
     }
-    let table_name = table.name.value.as_str();
-    let satisfied = dict.relationships.iter().any(|rel| {
-        let Some(join) = &rel.join else { return false };
-        // The FK column must appear on one side of some conjunct, and the
-        // corresponding other side must carry PrimaryKey.
-        join.conjuncts.iter().any(|conj| {
-            let sides = [(&conj.lhs, &conj.rhs), (&conj.rhs, &conj.lhs)];
-            sides.iter().any(|(fk_side, pk_side)| {
-                if fk_side.table != table_name || fk_side.column != col.name.value {
-                    return false;
-                }
-                let Some(other_tbl) = dict.table(&pk_side.table) else {
-                    return false;
-                };
-                let Some(other_col) = other_tbl.column(&pk_side.column) else {
-                    return false;
-                };
-                other_col.has(PrimaryKey)
-            })
-        })
-    });
-    if !satisfied {
+    if dict.resolve_foreign_key(table, col).is_none() {
         let fk_span = col
             .constraints
             .iter()

--- a/crates/data-dict/tests/snapshots/validate_data__foreign_key_incomparable_type_not_verified.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__foreign_key_incomparable_type_not_verified.snap
@@ -1,0 +1,35 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: item
+    source:
+      parquet: item.parquet
+    columns:
+      - name: category_id
+        type: string
+        constraints: [foreign_key]
+        examples: ["{}"]
+  - name: category
+    source:
+      parquet: category.parquet
+    columns:
+      - name: id
+        type: string
+        constraints: [primary_key]
+        examples: ["{}"]
+relationships:
+  - join: item.category_id = category.id
+    cardinality: many-to-one
+────────────────────────────────────────
+warning[D06]: Referential integrity can only be verified for comparable types.
+  --> dict.yaml:10:23
+   |
+LL |   - name: item
+...
+LL |       - name: category_id
+LL |         type: string
+LL |         constraints: [foreign_key]
+   |                       ^^^^^^^^^^^ can't be verified against `category.id`: JSON values aren't comparable

--- a/crates/data-dict/tests/snapshots/validate_data__foreign_key_orphan_value_reported.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__foreign_key_orphan_value_reported.snap
@@ -1,0 +1,35 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: item
+    source:
+      parquet: item.parquet
+    columns:
+      - name: category_id
+        type: number(id)
+        constraints: [foreign_key]
+        examples: [1, 2]
+  - name: category
+    source:
+      parquet: category.parquet
+    columns:
+      - name: id
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+relationships:
+  - join: item.category_id = category.id
+    cardinality: many-to-one
+────────────────────────────────────────
+error[D05]: A foreign key's values must all appear in the primary key it references.
+  --> dict.yaml:10:23
+   |
+LL |   - name: item
+...
+LL |       - name: category_id
+LL |         type: number(id)
+LL |         constraints: [foreign_key]
+   |                       ^^^^^^^^^^^ has 1 value not found in `category.id` (`5`; row: 3)

--- a/crates/data-dict/tests/validate_data.rs
+++ b/crates/data-dict/tests/validate_data.rs
@@ -9,7 +9,7 @@ mod common;
 use common::{assert_snapshot, temp_dir, write_dict};
 
 use std::fs::File;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use data_dict::{Problem, ProblemKind, ProblemSet, Status, validate_data, validate_meta};
@@ -1084,4 +1084,251 @@ fn int_backed_decimal_unique_column_passes() {
     );
 
     assert_eq!(validate_data(&yaml, None).status(), Status::Ok);
+}
+
+// --- Foreign keys (D05/D06) -------------------------------------------------
+
+/// Write a single-column parquet file at `path`.
+fn write_single_column(
+    path: &Path,
+    schema_col: &str,
+    write: impl FnOnce(&mut SerializedColumnWriter),
+) {
+    let message = format!("message schema {{ {schema_col}; }}");
+    let schema = Arc::new(parse_message_type(&message).unwrap());
+    let file = File::create(path).unwrap();
+    let mut writer =
+        SerializedFileWriter::new(file, schema, Arc::new(WriterProperties::builder().build()))
+            .unwrap();
+    let mut rg = writer.next_row_group().unwrap();
+    let mut col = rg.next_column().unwrap().unwrap();
+    write(&mut col);
+    col.close().unwrap();
+    rg.close().unwrap();
+    writer.close().unwrap();
+}
+
+/// Build a two-table dictionary with a foreign key `item.category_id` →
+/// `category.id`, backed by two single-column parquet files. `col_type` and
+/// `examples` supply the dictionary type and representation for both columns.
+fn build_fk(
+    child_schema: &str,
+    child_write: impl FnOnce(&mut SerializedColumnWriter),
+    parent_schema: &str,
+    parent_write: impl FnOnce(&mut SerializedColumnWriter),
+    col_type: &str,
+    examples: &str,
+) -> PathBuf {
+    let dir = temp_dir();
+    write_single_column(&dir.join("item.parquet"), child_schema, child_write);
+    write_single_column(&dir.join("category.parquet"), parent_schema, parent_write);
+    write_dict(
+        &dir,
+        &formatdoc! {"
+            tables:
+              - name: item
+                source:
+                  parquet: item.parquet
+                columns:
+                  - name: category_id
+                    type: {col_type}
+                    constraints: [foreign_key]
+                    examples: {examples}
+              - name: category
+                source:
+                  parquet: category.parquet
+                columns:
+                  - name: id
+                    type: {col_type}
+                    constraints: [primary_key]
+                    examples: {examples}
+            relationships:
+              - join: item.category_id = category.id
+                cardinality: many-to-one
+        "},
+    )
+}
+
+#[test]
+fn foreign_key_orphan_value_reported() {
+    // Child id 5 (row 3) has no matching primary key in the parent.
+    let yaml = build_fk(
+        "REQUIRED INT64 category_id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 5], None, None)
+                .unwrap();
+        },
+        "REQUIRED INT64 id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 3], None, None)
+                .unwrap();
+        },
+        "number(id)",
+        "[1, 2]",
+    );
+    let result = validate_data(&yaml, None);
+
+    assert_eq!(result.status(), Status::Error, "got {:?}", result.items);
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D05"),
+                kind: ProblemKind::ForeignKeyNotFound { column, references, count: 1, rows, values },
+                ..
+            }] if column == "category_id"
+                && references == "category.id"
+                && rows == &[3]
+                && values == &["5"]
+        ),
+        "got {:?}",
+        result.items
+    );
+    #[cfg(unix)]
+    assert_snapshot!(common::diagnostic(
+        &yaml,
+        &result.render(common::SNAPSHOT_STYLE).join("\n")
+    ));
+}
+
+#[test]
+fn foreign_key_all_values_present_ok() {
+    let yaml = build_fk(
+        "REQUIRED INT64 category_id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 1], None, None)
+                .unwrap();
+        },
+        "REQUIRED INT64 id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 3], None, None)
+                .unwrap();
+        },
+        "number(id)",
+        "[1, 2]",
+    );
+    let result = validate_data(&yaml, None);
+    assert_eq!(result.status(), Status::Ok, "got {:?}", result.items);
+}
+
+#[test]
+fn foreign_key_null_values_are_exempt() {
+    // Rows: 1 = 1, 2 = null, 3 = 5. The null references nothing (exempt); only
+    // the orphan 5 at row 3 is reported, proving null rows are skipped and row
+    // numbering still counts them.
+    let yaml = build_fk(
+        "OPTIONAL INT64 category_id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 5], Some(&[1, 0, 1]), None)
+                .unwrap();
+        },
+        "REQUIRED INT64 id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 3], None, None)
+                .unwrap();
+        },
+        "number(id)",
+        "[1, 2]",
+    );
+    let result = validate_data(&yaml, None);
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D05"),
+                kind: ProblemKind::ForeignKeyNotFound { count: 1, rows, values, .. },
+                ..
+            }] if rows == &[3] && values == &["5"]
+        ),
+        "got {:?}",
+        result.items
+    );
+}
+
+#[test]
+fn foreign_key_string_orphan_reported() {
+    let yaml = build_fk(
+        "REQUIRED BYTE_ARRAY category_id (UTF8)",
+        write_strings(&["a", "b", "z"]),
+        "REQUIRED BYTE_ARRAY id (UTF8)",
+        write_strings(&["a", "b", "c"]),
+        "string",
+        "[a, b]",
+    );
+    let result = validate_data(&yaml, None);
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D05"),
+                kind: ProblemKind::ForeignKeyNotFound { references, count: 1, rows, values, .. },
+                ..
+            }] if references == "category.id" && rows == &[3] && values == &["z"]
+        ),
+        "got {:?}",
+        result.items
+    );
+}
+
+#[test]
+fn foreign_key_across_int_widths_ok() {
+    // An INT32 child against an INT64 parent: both normalize to i64, so equal
+    // ids match despite the differing physical width.
+    let yaml = build_fk(
+        "REQUIRED INT32 category_id",
+        |col| {
+            col.typed::<Int32Type>()
+                .write_batch(&[1, 2], None, None)
+                .unwrap();
+        },
+        "REQUIRED INT64 id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 3], None, None)
+                .unwrap();
+        },
+        "number(id)",
+        "[1, 2]",
+    );
+    let result = validate_data(&yaml, None);
+    assert_eq!(result.status(), Status::Ok, "got {:?}", result.items);
+}
+
+#[test]
+fn foreign_key_incomparable_type_not_verified() {
+    // The foreign-key column is JSON, whose values can't be compared, so the
+    // reference is reported as unverified (D06) rather than checked.
+    let yaml = build_fk(
+        "REQUIRED BYTE_ARRAY category_id (JSON)",
+        write_strings(&[r#"{"a":1}"#]),
+        "REQUIRED BYTE_ARRAY id (UTF8)",
+        write_strings(&["x"]),
+        "string",
+        r#"["{}"]"#,
+    );
+    let result = validate_data(&yaml, None);
+    assert_eq!(result.status(), Status::Warning, "got {:?}", result.items);
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D06"),
+                kind: ProblemKind::ReferentialIntegrityNotVerified { column, references, reason },
+                ..
+            }] if column == "category_id" && references == "category.id" && reason == "json"
+        ),
+        "got {:?}",
+        result.items
+    );
+    #[cfg(unix)]
+    assert_snapshot!(common::diagnostic(
+        &yaml,
+        &result.render(common::SNAPSHOT_STYLE).join("\n")
+    ));
 }

--- a/site/spec.md
+++ b/site/spec.md
@@ -195,7 +195,7 @@ NB: when `time_zone` is present, write the column's `range` as plain, zoneless d
 The `constraints` property is a list of constraint names. The supported constraints are:
 
 * `primary_key`: the set of columns with the `primary_key` constraint uniquely identifies each row. Implies `required` and `unique`.
-* `foreign_key`: the column references a primary key in another table (or in the current table, if a self-join). The specific relationship is defined in [`relationships`](#relationships).
+* `foreign_key`: the column references a primary key in another table (or in the current table, if a self-join). The specific relationship is defined in [`relationships`](#relationships). Validating the data checks that every value appears in the referenced primary key (see D05/D06 in [validation](validation.md)).
 * `required`: the column does not contain null/missing values.
 * `unique`: the column's values are distinct (no duplicates). Null/missing values are exempt — a `unique` column may contain multiple nulls, and nulls are never treated as duplicates.
 

--- a/site/validation.md
+++ b/site/validation.md
@@ -73,6 +73,8 @@ A validator reports two severities of problem: **errors** and **warnings**. The 
 | D02 | Duplicate values | E | A `unique` column contains duplicate values, or the combination of all `primary_key` columns does not uniquely identify every row. Only [comparable types](#comparable-types) are checked. Null/missing values are never counted as duplicates; for a composite primary key, a row with a null in any key column is not compared. |
 | D03 | Uniqueness not verified | W | A `unique` column or `primary_key` uses a type whose values can't be reliably compared, so its uniqueness was not checked. |
 | D04 | Value outside enum | E | An `enum` column contains a (non-null) value that is not one of its declared `values`. |
+| D05 | Foreign key not found | E | A `foreign_key` column contains a (non-null) value that does not appear in the `primary_key` column it references. Only [comparable types](#comparable-types) are checked; null/missing values are exempt (a null foreign key references nothing). Only single-column foreign keys are checked. |
+| D06 | Referential integrity not verified | W | A `foreign_key` column, or the `primary_key` it references, uses a type whose values can't be reliably compared, so the reference was not checked. |
 
 : {tbl-colwidths="[7,23,5,65]"}
 
@@ -87,3 +89,5 @@ For **Parquet**:
 * JSON and BSON, whose byte representation does not determine equality (two documents can differ only in whitespace or key order and still be equal), are **not** compared. Neither is any Parquet logical type the validator does not recognize — including future types such as `VARIANT` or `GEOMETRY`.
 
 For a non-comparable column, running the check anyway could silently miss duplicates and pass a dataset that should fail, so the check is skipped with a D03 warning instead. A composite primary key is skipped whole if any of its columns is non-comparable.
+
+The foreign-key check (D05) is governed by the same comparability rule: the foreign-key column and the primary-key column it references are compared by the same normalized value form, so both must be comparable. If either uses a non-comparable type, the reference could silently mismatch, so the check is skipped with a D06 warning instead.


### PR DESCRIPTION
Mostly uses the same infrastructure as the uniqueness check.

We only check single-column foreign keys, composite keys are skipped.

Closes #67.