### PR TITLE
Require aliases for self-joins

### DIFF
--- a/crates/data-dict-cli/skills/write-data-dict.md
+++ b/crates/data-dict-cli/skills/write-data-dict.md
@@ -95,7 +95,9 @@ a plausible-sounding description for a column whose meaning you had to guess.
 5.  **Define relationships.** For every foreign key, add a relationship entry
     with `description`, `cardinality` (`one-to-many` or `many-to-one`),
     `join`, and any `conflicts` (column names that appear in both tables with
-    different meanings).
+    different meanings). A self-join needs an `aliases` entry per side, naming
+    the role each plays (`join: mother.otter_no = pup.pup_number` with
+    `aliases: {mother: otters, pup: otters}`).
 
 6.  **Build the glossary.** Add definitions for domain-specific terms used in
     descriptions. If a word would be unfamiliar to a new team member or an AI

--- a/crates/data-dict/src/lower.rs
+++ b/crates/data-dict/src/lower.rs
@@ -10,8 +10,8 @@ use quarto_yaml::YamlWithSourceInfo;
 use crate::assert_expr::AssertExpr;
 use crate::join_expr::JoinExpr;
 use crate::model::{
-    Assertion, Cardinality, Column, Constraint, DataDict, Relationship, Representation, Scalar,
-    Source, Spanned, Table,
+    Alias, Assertion, Cardinality, Column, Constraint, DataDict, Relationship, Representation,
+    Scalar, Source, Spanned, Table,
 };
 use crate::problem::{Problem, ProblemSet, Severity, subspan};
 
@@ -274,6 +274,7 @@ fn lower_relationship(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> R
     let mut cardinality: Option<Spanned<Cardinality>> = None;
     let mut join_text: Option<Spanned<String>> = None;
     let mut conflicts: Vec<Spanned<String>> = Vec::new();
+    let mut aliases: Vec<Alias> = Vec::new();
 
     for entry in entries {
         let Some(key) = entry.key.yaml.as_str() else {
@@ -298,6 +299,21 @@ fn lower_relationship(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> R
                         if let Some(s) = c.yaml.as_str() {
                             conflicts.push(Spanned::new(s.to_string(), c.source_info.clone()));
                         }
+                    }
+                }
+            }
+            "aliases" => {
+                if let Some(items) = entry.value.as_hash() {
+                    for a in items {
+                        let (Some(name), Some(table)) =
+                            (a.key.yaml.as_str(), a.value.yaml.as_str())
+                        else {
+                            continue;
+                        };
+                        aliases.push(Alias {
+                            name: Spanned::new(name.to_string(), a.key.source_info.clone()),
+                            table: Spanned::new(table.to_string(), a.value_span.clone()),
+                        });
                     }
                 }
             }
@@ -329,5 +345,6 @@ fn lower_relationship(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> R
         join_text,
         join,
         conflicts,
+        aliases,
     }
 }

--- a/crates/data-dict/src/model.rs
+++ b/crates/data-dict/src/model.rs
@@ -48,10 +48,11 @@ impl DataDict {
             let Some(join) = &rel.join else { continue };
             for conj in &join.conjuncts {
                 for (fk_side, pk_side) in [(&conj.lhs, &conj.rhs), (&conj.rhs, &conj.lhs)] {
-                    if fk_side.table != table_name || fk_side.column != col.name.value {
+                    if rel.resolve(&fk_side.table) != table_name || fk_side.column != col.name.value
+                    {
                         continue;
                     }
-                    let Some(other_tbl) = self.table(&pk_side.table) else {
+                    let Some(other_tbl) = self.table(rel.resolve(&pk_side.table)) else {
                         continue;
                     };
                     let Some(other_col) = other_tbl.column(&pk_side.column) else {
@@ -242,6 +243,27 @@ pub struct Relationship {
     /// S06) skip the relationship.
     pub join: Option<JoinExpr>,
     pub conflicts: Vec<Spanned<String>>,
+    /// Alias declarations, in source order. Scoped to this relationship.
+    pub aliases: Vec<Alias>,
+}
+
+impl Relationship {
+    /// The table a name in the `join` refers to: the target of the alias of
+    /// that name, or `name` itself when no alias declares it.
+    pub fn resolve<'a>(&'a self, name: &'a str) -> &'a str {
+        self.alias(name).map_or(name, |a| a.table.value.as_str())
+    }
+
+    pub fn alias(&self, name: &str) -> Option<&Alias> {
+        self.aliases.iter().find(|a| a.name.value == name)
+    }
+}
+
+/// One `aliases` entry: the alias itself and the table it stands for.
+#[derive(Debug, Clone)]
+pub struct Alias {
+    pub name: Spanned<String>,
+    pub table: Spanned<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -23,7 +23,7 @@ use quarto_yaml_validation::{Schema, SchemaRegistry, ValidationDiagnostic, Valid
 use crate::assert_expr::{self, CheckEnv, ColumnKind};
 use crate::join_expr::{JoinExpr, QCol};
 use crate::model::{
-    Assertion, Cardinality, Column, DataDict, Representation, Scalar, Spanned, Table,
+    Assertion, Cardinality, Column, DataDict, Relationship, Representation, Scalar, Spanned, Table,
 };
 use crate::problem::{Problem, ProblemKind, ProblemSet, Suggestion, subspan};
 use crate::{SourceContext, lower};
@@ -209,6 +209,9 @@ fn check_spec(dict: &DataDict, out: &mut ProblemSet) {
     validate_s04_join_table_count(dict, out);
     validate_s05_conflicts_present_on_both_sides(dict, out);
     validate_s06_cardinality_consistency(dict, out);
+    validate_s25_unaliased_self_join(dict, out);
+    validate_s26_alias_shadows_table(dict, out);
+    validate_s27_unused_alias(dict, out);
     validate_s16_single_table_description(dict, out);
 
     let mut seen_tables: HashMap<String, SourceInfo> = HashMap::new();
@@ -339,15 +342,31 @@ fn run_assertion_check(
 
 fn validate_s02_relationship_table_refs(dict: &DataDict, out: &mut ProblemSet) {
     for rel in &dict.relationships {
+        for alias in &rel.aliases {
+            if dict.table(&alias.table.value).is_none() {
+                out.push_spec_error(
+                    "S02",
+                    "An alias must name a known table.",
+                    format!("table `{}` is not defined", alias.table.value),
+                    [
+                        rel.join_text.span.clone(),
+                        alias.name.span.clone(),
+                        alias.table.span.clone(),
+                    ],
+                );
+            }
+        }
         let Some(join) = &rel.join else { continue };
         for q in join.qcols() {
-            if dict.table(&q.table).is_none() {
+            // An alias that points at a missing table is reported above; here
+            // the name resolves to itself, so a second report would repeat it.
+            if rel.alias(&q.table).is_none() && dict.table(&q.table).is_none() {
                 let span = subspan(&rel.join_text.span, q.start, q.end)
                     .unwrap_or_else(|| rel.join_text.span.clone());
                 out.push_spec_error(
                     "S02",
-                    "A `join` must refer to known tables.",
-                    format!("table `{}` is not defined", q.table),
+                    "A `join` must refer to known tables or aliases.",
+                    format!("`{}` is neither a table nor an alias", q.table),
                     [span],
                 );
             }
@@ -363,7 +382,8 @@ fn validate_s03_relationship_column_refs(dict: &DataDict, out: &mut ProblemSet) 
             for q in join.qcols() {
                 // Skip if the table doesn't exist — S02 handles that case
                 // and a column report would be noise.
-                let Some(table) = dict.table(&q.table) else {
+                let table_name = rel.resolve(&q.table);
+                let Some(table) = dict.table(table_name) else {
                     continue;
                 };
                 if table.column(&q.column).is_none() {
@@ -372,7 +392,7 @@ fn validate_s03_relationship_column_refs(dict: &DataDict, out: &mut ProblemSet) 
                     out.push_spec_error(
                         "S03",
                         "A `join` must refer to known columns.",
-                        format!("table `{}` has no column `{}`", q.table, q.column),
+                        format!("table `{table_name}` has no column `{}`", q.column),
                         [span],
                     );
                 }
@@ -388,17 +408,94 @@ fn validate_s03_relationship_column_refs(dict: &DataDict, out: &mut ProblemSet) 
 
 fn validate_s04_join_table_count(dict: &DataDict, out: &mut ProblemSet) {
     // Parse failures are emitted during lowering. Here we only check the
-    // table-count invariant on successfully parsed joins.
+    // table-count invariant on successfully parsed joins. One name on both
+    // sides is S25's case, not S04's.
     for rel in &dict.relationships {
         let Some(join) = &rel.join else { continue };
-        let tables = join.tables();
-        if tables.is_empty() || tables.len() > 2 {
+        let names = join.tables();
+        if names.len() > 2 {
             out.push_spec_error(
                 "S04",
-                "A `join` must reference one (self-join) or two tables.",
-                format!("this `join` references {} tables", tables.len()),
+                "A `join` must reference exactly two tables.",
+                format!("this `join` references {} tables", names.len()),
                 [rel.join_text.span.clone()],
             );
+        }
+    }
+}
+
+// --- S25 --------------------------------------------------------------
+
+/// A join needs two row sets. Two sides denote the same rows when they share a
+/// name, or when they resolve to the same table without each being its own
+/// alias — the self-join the spec requires aliases for.
+fn validate_s25_unaliased_self_join(dict: &DataDict, out: &mut ProblemSet) {
+    for rel in &dict.relationships {
+        let Some(join) = &rel.join else { continue };
+        let names = join.tables();
+        let (found, table) = match names.as_slice() {
+            [only] => (
+                format!("`{only}` is on both sides of the join"),
+                rel.resolve(only).to_string(),
+            ),
+            [a, b] => {
+                let table = rel.resolve(a);
+                if table != rel.resolve(b) || (rel.alias(a).is_some() && rel.alias(b).is_some()) {
+                    continue;
+                }
+                (
+                    format!("`{a}` and `{b}` both refer to table `{table}`"),
+                    table.to_string(),
+                )
+            }
+            _ => continue,
+        };
+        out.push_spec_error(
+            "S25",
+            "A self-join must give each side its own alias.",
+            found,
+            [rel.join_text.span.clone()],
+        );
+        out.hint_last(format!(
+            "Name the role each side plays, e.g. `aliases: {{parent: {table}, child: {table}}}`, \
+             and use those names in the `join`."
+        ));
+    }
+}
+
+// --- S26 / S27 ---------------------------------------------------------
+
+fn validate_s26_alias_shadows_table(dict: &DataDict, out: &mut ProblemSet) {
+    for rel in &dict.relationships {
+        for alias in &rel.aliases {
+            if dict.table(&alias.name.value).is_some() {
+                out.push_spec_error(
+                    "S26",
+                    "An alias must not have the same name as a table.",
+                    format!(
+                        "`{}` is already a table in this dictionary",
+                        alias.name.value
+                    ),
+                    [rel.join_text.span.clone(), alias.name.span.clone()],
+                );
+            }
+        }
+    }
+}
+
+fn validate_s27_unused_alias(dict: &DataDict, out: &mut ProblemSet) {
+    for rel in &dict.relationships {
+        let Some(join) = &rel.join else { continue };
+        let names = join.tables();
+        for alias in &rel.aliases {
+            if !names.contains(&alias.name.value.as_str()) {
+                out.push_spec_warning(
+                    "S27",
+                    "Every alias should be used by its relationship's `join`.",
+                    format!("alias `{}` is never used", alias.name.value),
+                    [rel.join_text.span.clone(), alias.name.span.clone()],
+                );
+            }
         }
     }
 }
@@ -434,9 +531,15 @@ fn validate_s05_conflicts_present_on_both_sides(dict: &DataDict, out: &mut Probl
             continue;
         }
         let Some(join) = &rel.join else { continue };
-        let tables = join.tables();
-        // For a self-join, the "both sides" reduces to the single table; for
-        // a normal join, both tables must contain the column.
+        // Two aliases of one table are one table for this check, so resolve
+        // and dedup before looking the column up.
+        let mut tables: Vec<&str> = Vec::new();
+        for name in join.tables() {
+            let resolved = rel.resolve(name);
+            if !tables.contains(&resolved) {
+                tables.push(resolved);
+            }
+        }
         for c in &rel.conflicts {
             let mut missing_from: Vec<&str> = Vec::new();
             for t_name in &tables {
@@ -488,7 +591,7 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
         // cardinality against a column that doesn't exist would just produce a
         // redundant, confusing S06.
         let all_cols_resolve = join.qcols().all(|q| {
-            dict.table(&q.table)
+            dict.table(rel.resolve(&q.table))
                 .is_some_and(|t| t.column(&q.column).is_some())
         });
         if !all_cols_resolve {
@@ -502,8 +605,8 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
         let Some(first) = join.conjuncts.first() else {
             continue;
         };
-        let lhs_table = first.lhs.table.clone();
-        let rhs_table = first.rhs.table.clone();
+        let lhs_side = first.lhs.table.clone();
+        let rhs_side = first.rhs.table.clone();
 
         // Which columns are "the join side" for each table?  For the
         // single-conjunct equality case this is straightforward. For
@@ -515,9 +618,9 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
         // joins without producing noise for legitimate overlap joins.
 
         let lhs_cols_unique =
-            side_has_unique_implied(dict, &lhs_table, join, /* use_lhs = */ true);
+            side_has_unique_implied(dict, rel, &lhs_side, join, /* use_lhs = */ true);
         let rhs_cols_unique =
-            side_has_unique_implied(dict, &rhs_table, join, /* use_lhs = */ false);
+            side_has_unique_implied(dict, rel, &rhs_side, join, /* use_lhs = */ false);
 
         let card_span = rel.cardinality.span.clone();
         match rel.cardinality.value {
@@ -528,7 +631,7 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
                         "A `one-to-one` join must have `primary_key` or `unique` columns on both sides.",
                         format!(
                             "the join columns on `{}` or `{}` are not marked `primary_key` or `unique`",
-                            lhs_table, rhs_table
+                            lhs_side, rhs_side
                         ),
                         [
                             rel.join_text.span.clone(),
@@ -546,7 +649,7 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
                         "A `one-to-many` join must have a `primary_key` or `unique` column on its left (\"one\") side.",
                         format!(
                             "the left-side join column on `{}` is not marked `primary_key` or `unique`",
-                            lhs_table
+                            lhs_side
                         ),
                         [
                             rel.join_text.span.clone(),
@@ -562,7 +665,7 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
                         "A `many-to-one` join must have a `primary_key` or `unique` column on its right (\"one\") side.",
                         format!(
                             "the right-side join column on `{}` is not marked `primary_key` or `unique`",
-                            rhs_table
+                            rhs_side
                         ),
                         [
                             rel.join_text.span.clone(),
@@ -575,18 +678,21 @@ fn validate_s06_cardinality_consistency(dict: &DataDict, out: &mut ProblemSet) {
     }
 }
 
+/// `side` is the name as it appears in the join — an alias or a table name —
+/// so the two sides of a self-join stay distinguishable.
 fn side_has_unique_implied(
     dict: &DataDict,
-    table_name: &str,
+    rel: &Relationship,
+    side: &str,
     join: &JoinExpr,
     use_lhs: bool,
 ) -> bool {
-    let Some(table) = dict.table(table_name) else {
+    let Some(table) = dict.table(rel.resolve(side)) else {
         return false;
     };
     join.conjuncts.iter().any(|conj| {
         let q: &QCol = if use_lhs { &conj.lhs } else { &conj.rhs };
-        if q.table != table_name {
+        if q.table != side {
             return false;
         }
         table

--- a/crates/data-dict/tests/fixtures/spec/aliases-role-playing-ok.yaml
+++ b/crates/data-dict/tests/fixtures/spec/aliases-role-playing-ok.yaml
@@ -1,0 +1,43 @@
+# expected: valid
+# Aliases where they're optional: two tables joined twice, each join meaning
+# something different. The alias names the role rather than telling two sides
+# apart.
+
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+
+tables:
+  - name: flights
+    columns:
+      - name: id
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+      - name: origin
+        type: string
+        constraints: [foreign_key]
+        examples: ["EWR", "LGA"]
+      - name: dest
+        type: string
+        constraints: [foreign_key]
+        examples: ["IAH", "ATL"]
+
+  - name: airports
+    columns:
+      - name: faa
+        type: string
+        constraints: [primary_key]
+        examples: ["EWR", "IAH"]
+      - name: name
+        type: string
+        examples: ["Newark Liberty Intl", "George Bush Intercontinental"]
+
+relationships:
+  - join: flights.origin = origin_airport.faa
+    aliases:
+      origin_airport: airports
+    cardinality: many-to-one
+  - join: flights.dest = dest_airport.faa
+    aliases:
+      dest_airport: airports
+    cardinality: many-to-one

--- a/crates/data-dict/tests/fixtures/spec/aliases-self-join-ok.yaml
+++ b/crates/data-dict/tests/fixtures/spec/aliases-self-join-ok.yaml
@@ -1,0 +1,28 @@
+# expected: valid
+# The self-join the spec asks for: an alias per side. `pup_number` is a
+# `foreign_key`, so this also exercises S01 resolving a foreign key through an
+# alias back to `otters.otter_no`.
+
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+description: Sea otters and their dependent pups.
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        constraints: [foreign_key]
+        examples: [1, 2]
+
+relationships:
+  - join: mother.otter_no = pup.pup_number
+    aliases:
+      mother: otters
+      pup: otters
+    cardinality: one-to-many
+    description: Links a female otter to her dependent pup's own record.

--- a/crates/data-dict/tests/fixtures/spec/s02-alias-unknown-table.yaml
+++ b/crates/data-dict/tests/fixtures/spec/s02-alias-unknown-table.yaml
@@ -1,0 +1,23 @@
+# expected: S02
+# The alias `pup` points at `otter`, but the table is `otters`. The report
+# lands on the alias, not on the join that uses it.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: mother.otter_no = pup.pup_number
+    aliases:
+      mother: otters
+      pup: otter
+    cardinality: one-to-many

--- a/crates/data-dict/tests/fixtures/spec/s06-self-join-one-to-many.yaml
+++ b/crates/data-dict/tests/fixtures/spec/s06-self-join-one-to-many.yaml
@@ -1,7 +1,7 @@
 # expected: S06
 # Recreated from the bundled `otters` example. A `one-to-many` self-join
-# `otters.pup_number = otters.otter_no` makes `pup_number` the "one" side, so
-# it must be `primary_key` or `unique`; it is neither, so S06 fires.
+# `pup.pup_number = mother.otter_no` makes `pup_number` the "one" side, so it
+# must be `primary_key` or `unique`; it is neither, so S06 fires.
 
 $version: "0.1.0"
 
@@ -20,5 +20,8 @@ tables:
         examples: ["found in river", "tagged"]
 
 relationships:
-  - join: otters.pup_number = otters.otter_no
+  - join: pup.pup_number = mother.otter_no
+    aliases:
+      pup: otters
+      mother: otters
     cardinality: one-to-many

--- a/crates/data-dict/tests/fixtures/spec/s25-half-aliased-self-join.yaml
+++ b/crates/data-dict/tests/fixtures/spec/s25-half-aliased-self-join.yaml
@@ -1,0 +1,23 @@
+# expected: S25
+# Only one side is aliased, so `mother` and `otters` both stand for the same
+# table and the join still doesn't say which rows are which. Both sides need
+# their own alias.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: otters.pup_number = mother.otter_no
+    aliases:
+      mother: otters
+    cardinality: many-to-one

--- a/crates/data-dict/tests/fixtures/spec/s25-unaliased-self-join.yaml
+++ b/crates/data-dict/tests/fixtures/spec/s25-unaliased-self-join.yaml
@@ -1,0 +1,21 @@
+# expected: S25
+# The self-join names `otters` on both sides, so nothing says the two sides are
+# different rows. `many-to-one` puts the "one" side on the `primary_key`, so
+# S06 stays quiet and only S25 fires.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: otters.pup_number = otters.otter_no
+    cardinality: many-to-one

--- a/crates/data-dict/tests/fixtures/spec/s26-alias-shadows-table.yaml
+++ b/crates/data-dict/tests/fixtures/spec/s26-alias-shadows-table.yaml
@@ -1,0 +1,23 @@
+# expected: S26
+# The alias `otters` is also a table, so `otters.otter_no` in the join could be
+# read either way.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: otters.pup_number = mother.otter_no
+    aliases:
+      otters: otters
+      mother: otters
+    cardinality: many-to-one

--- a/crates/data-dict/tests/fixtures/spec/s27-unused-alias.yaml
+++ b/crates/data-dict/tests/fixtures/spec/s27-unused-alias.yaml
@@ -1,0 +1,30 @@
+# expected: S27 (warning)
+# `category` is declared but the join names `food_category` directly, so the
+# alias does nothing. Warning only: the join itself is still valid.
+
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+
+tables:
+  - name: food
+    columns:
+      - name: id
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+      - name: food_category_id
+        type: number(id)
+        examples: [1, 2]
+
+  - name: food_category
+    columns:
+      - name: id
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+
+relationships:
+  - join: food.food_category_id = food_category.id
+    aliases:
+      category: food_category
+    cardinality: many-to-one

--- a/crates/data-dict/tests/snapshots/validate_spec__s02_alias_unknown_table.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s02_alias_unknown_table.snap
@@ -1,0 +1,34 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+# expected: S02
+# The alias `pup` points at `otter`, but the table is `otters`. The report
+# lands on the alias, not on the join that uses it.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: mother.otter_no = pup.pup_number
+    aliases:
+      mother: otters
+      pup: otter
+    cardinality: one-to-many
+────────────────────────────────────────
+error[S02]: An alias must name a known table.
+  --> spec/s02-alias-unknown-table.yaml:22:12
+   |
+LL |   - join: mother.otter_no = pup.pup_number
+...
+LL |       pup: otter
+   |            ^^^^^ table `otter` is not defined

--- a/crates/data-dict/tests/snapshots/validate_spec__s06_self_join_one_to_many.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s06_self_join_one_to_many.snap
@@ -3,8 +3,8 @@ source: crates/data-dict/tests/validate_spec.rs
 ---
 # expected: S06
 # Recreated from the bundled `otters` example. A `one-to-many` self-join
-# `otters.pup_number = otters.otter_no` makes `pup_number` the "one" side, so
-# it must be `primary_key` or `unique`; it is neither, so S06 fires.
+# `pup.pup_number = mother.otter_no` makes `pup_number` the "one" side, so it
+# must be `primary_key` or `unique`; it is neither, so S06 fires.
 
 $version: "0.1.0"
 
@@ -23,12 +23,16 @@ tables:
         examples: ["found in river", "tagged"]
 
 relationships:
-  - join: otters.pup_number = otters.otter_no
+  - join: pup.pup_number = mother.otter_no
+    aliases:
+      pup: otters
+      mother: otters
     cardinality: one-to-many
 ────────────────────────────────────────
 error[S06]: A `one-to-many` join must have a `primary_key` or `unique` column on its left ("one") side.
-  --> spec/s06-self-join-one-to-many.yaml:24:18
+  --> spec/s06-self-join-one-to-many.yaml:27:18
    |
-LL |   - join: otters.pup_number = otters.otter_no
+LL |   - join: pup.pup_number = mother.otter_no
+...
 LL |     cardinality: one-to-many
-   |                  ^^^^^^^^^^^ the left-side join column on `otters` is not marked `primary_key` or `unique`
+   |                  ^^^^^^^^^^^ the left-side join column on `pup` is not marked `primary_key` or `unique`

--- a/crates/data-dict/tests/snapshots/validate_spec__s25_half_aliased_self_join.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s25_half_aliased_self_join.snap
@@ -1,0 +1,34 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+# expected: S25
+# Only one side is aliased, so `mother` and `otters` both stand for the same
+# table and the join still doesn't say which rows are which. Both sides need
+# their own alias.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: otters.pup_number = mother.otter_no
+    aliases:
+      mother: otters
+    cardinality: many-to-one
+────────────────────────────────────────
+error[S25]: A self-join must give each side its own alias.
+  --> spec/s25-half-aliased-self-join.yaml:20:11
+   |
+LL |   - join: otters.pup_number = mother.otter_no
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `otters` and `mother` both refer to table `otters`
+   |
+   = help: Name the role each side plays, e.g. `aliases: {parent: otters, child: otters}`, and use those names in the `join`.

--- a/crates/data-dict/tests/snapshots/validate_spec__s25_unaliased_self_join.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s25_unaliased_self_join.snap
@@ -1,0 +1,32 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+# expected: S25
+# The self-join names `otters` on both sides, so nothing says the two sides are
+# different rows. `many-to-one` puts the "one" side on the `primary_key`, so
+# S06 stays quiet and only S25 fires.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: otters.pup_number = otters.otter_no
+    cardinality: many-to-one
+────────────────────────────────────────
+error[S25]: A self-join must give each side its own alias.
+  --> spec/s25-unaliased-self-join.yaml:20:11
+   |
+LL |   - join: otters.pup_number = otters.otter_no
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `otters` is on both sides of the join
+   |
+   = help: Name the role each side plays, e.g. `aliases: {parent: otters, child: otters}`, and use those names in the `join`.

--- a/crates/data-dict/tests/snapshots/validate_spec__s26_alias_shadows_table.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s26_alias_shadows_table.snap
@@ -1,0 +1,34 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+# expected: S26
+# The alias `otters` is also a table, so `otters.otter_no` in the join could be
+# read either way.
+
+$version: "0.1.0"
+
+tables:
+  - name: otters
+    columns:
+      - name: otter_no
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2, 3]
+      - name: pup_number
+        type: number(id)
+        examples: [1, 2]
+
+relationships:
+  - join: otters.pup_number = mother.otter_no
+    aliases:
+      otters: otters
+      mother: otters
+    cardinality: many-to-one
+────────────────────────────────────────
+error[S26]: An alias must not have the same name as a table.
+  --> spec/s26-alias-shadows-table.yaml:21:7
+   |
+LL |   - join: otters.pup_number = mother.otter_no
+LL |     aliases:
+LL |       otters: otters
+   |       ^^^^^^ `otters` is already a table in this dictionary

--- a/crates/data-dict/tests/snapshots/validate_spec__s27_unused_alias.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s27_unused_alias.snap
@@ -1,12 +1,12 @@
 ---
 source: crates/data-dict/tests/validate_spec.rs
 ---
-# expected: S02
-# The relationship references `category` but that table doesn't exist; the
-# defined table is `food_category`. `food_category_id` is left unconstrained so
-# only S02 fires (a `foreign_key` would add S01, a missing column S03).
+# expected: S27 (warning)
+# `category` is declared but the join names `food_category` directly, so the
+# alias does nothing. Warning only: the join itself is still valid.
 
 $version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
 
 tables:
   - name: food
@@ -27,11 +27,15 @@ tables:
         examples: [1, 2]
 
 relationships:
-  - join: food.food_category_id = category.id
+  - join: food.food_category_id = food_category.id
+    aliases:
+      category: food_category
     cardinality: many-to-one
 ────────────────────────────────────────
-error[S02]: A `join` must refer to known tables or aliases.
-  --> spec/s02-missing-table.yaml:27:35
+warning[S27]: Every alias should be used by its relationship's `join`.
+  --> spec/s27-unused-alias.yaml:29:7
    |
-LL |   - join: food.food_category_id = category.id
-   |                                   ^^^^^^^^^^^ `category` is neither a table nor an alias
+LL |   - join: food.food_category_id = food_category.id
+LL |     aliases:
+LL |       category: food_category
+   |       ^^^^^^^^ alias `category` is never used

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -50,7 +50,10 @@ fn assert_valid_dict(body: &str) {
 /// Assert `body` validates with neither errors nor warnings — entirely clean.
 /// Stronger than [`assert_valid_dict`], which only checks for errors.
 fn assert_clean_dict(body: &str) {
-    let path = dict(body);
+    assert_clean(dict(body));
+}
+
+fn assert_clean(path: PathBuf) {
     let errors = diagnostics(&path, Severity::Error);
     assert!(
         errors.is_empty(),
@@ -173,6 +176,20 @@ fn failing_diagnostic(rel: &str) -> Diagnostic {
     Diagnostic {
         source: std::fs::read_to_string(&path).unwrap(),
         rendered: common::sanitize(&errors.join("\n"), &fixtures_root()),
+    }
+}
+
+/// [`failing_diagnostic`]'s counterpart for a fixture that validates but warns.
+fn warning_diagnostic(rel: &str) -> Diagnostic {
+    let path = fixture(rel);
+    assert_valid(path.clone());
+    let warnings = diagnostics(&path, Severity::Warning);
+    if warnings.is_empty() {
+        panic!("expected {rel} to warn, but it was clean");
+    }
+    Diagnostic {
+        source: std::fs::read_to_string(&path).unwrap(),
+        rendered: common::sanitize(&warnings.join("\n"), &fixtures_root()),
     }
 }
 
@@ -402,6 +419,11 @@ fn s02_missing_table() {
 }
 
 #[test]
+fn s02_alias_unknown_table() {
+    assert_snapshot!(failing_diagnostic("spec/s02-alias-unknown-table.yaml"));
+}
+
+#[test]
 fn s03_missing_column() {
     assert_snapshot!(failing_diagnostic("spec/s03-missing-column.yaml"));
 }
@@ -436,6 +458,74 @@ fn s06_cardinality_mismatch() {
 #[test]
 fn s06_self_join_one_to_many() {
     assert_snapshot!(failing_diagnostic("spec/s06-self-join-one-to-many.yaml"));
+}
+
+// --- aliases (S25/S26/S27) -----------------------------------------------
+
+#[test]
+fn s25_unaliased_self_join() {
+    assert_snapshot!(failing_diagnostic("spec/s25-unaliased-self-join.yaml"));
+}
+
+// One alias and one bare table name still leaves both sides standing for the
+// same rows, so aliasing half the join isn't enough.
+#[test]
+fn s25_half_aliased_self_join() {
+    assert_snapshot!(failing_diagnostic("spec/s25-half-aliased-self-join.yaml"));
+}
+
+// Two aliases of one table are two sides, so this is the self-join spelling the
+// spec asks for. Also covers S01 resolving a foreign key through an alias.
+#[test]
+fn aliases_self_join_ok() {
+    assert_clean(fixture("spec/aliases-self-join-ok.yaml"));
+}
+
+// Aliases are allowed where they aren't required: two tables joined twice, with
+// the alias naming each role.
+#[test]
+fn aliases_role_playing_ok() {
+    assert_clean(fixture("spec/aliases-role-playing-ok.yaml"));
+}
+
+#[test]
+fn s26_alias_shadows_table() {
+    assert_snapshot!(failing_diagnostic("spec/s26-alias-shadows-table.yaml"));
+}
+
+#[test]
+fn s27_unused_alias() {
+    assert_snapshot!(warning_diagnostic("spec/s27-unused-alias.yaml"));
+}
+
+// An alias resolves only within the relationship that declares it, so a second
+// relationship naming it gets S02 rather than the first one's table.
+#[test]
+fn alias_does_not_leak_between_relationships() {
+    assert_invalid_dict(
+        indoc! {"
+            tables:
+              - name: a
+                columns:
+                  - name: id
+                    type: number(id)
+                    constraints: [primary_key]
+                    examples: [1, 2]
+              - name: b
+                columns:
+                  - name: a_id
+                    type: number(id)
+                    examples: [1, 2]
+
+            relationships:
+              - join: b.a_id = parent.id
+                aliases: {parent: a}
+                cardinality: many-to-one
+              - join: b.a_id = parent.id
+                cardinality: many-to-one
+        "},
+        &["S02"],
+    );
 }
 
 // --- data representation (S07) -------------------------------------------

--- a/schema.yaml
+++ b/schema.yaml
@@ -145,6 +145,10 @@ object:
             join: string
             conflicts:
               arrayOf: string
+            # alias -> table name. S25/S26/S27 cover the semantic rules.
+            aliases:
+              object:
+                additionalProperties: string
 
     glossary:
       object:

--- a/site/spec.md
+++ b/site/spec.md
@@ -278,9 +278,10 @@ constraints:
 `relationships` is a list of join descriptors. Each entry describes how two tables are related.
 
 * `join` (required): a join expression of the form `table1.column = table2.column`, or `table1.date >= table2.start AND table1.date <= table2.end`.
-* `cardinality` (required): either `one-to-one`, `one-to-many`, or `many-to-one`. Describes the relationship from the left table to the right table in the join expression.
+* `cardinality` (required): either `one-to-one`, `one-to-many`, or `many-to-one`. Describes the relationship from the left side to the right side of the join expression.
 * `description`: human-readable description of the relationship. Only needed if it's not clear from the context.
-* `conflicts`: a list of column names that appear in both tables with different meanings. These fields would cause ambiguity in a join and may need to be renamed or dropped.
+* `conflicts`: a list of column names that appear on both sides of the join with different meanings. These fields would cause ambiguity in a join and may need to be renamed or dropped.
+* `aliases`: a map from alias to table name, naming the role each side of the join plays. See [aliases](#aliases).
 
 For example:
 
@@ -289,6 +290,36 @@ relationships:
   - join: food.food_category_id = food_category.id
     cardinality: many-to-one
     conflicts: [description]
+```
+
+### Aliases
+
+A join brings together two sets of rows. Usually they come from two different tables, so the table names are enough to tell the sides apart. When they don't, `aliases` gives each side its own name:
+
+```yaml
+relationships:
+  - join: mother.otter_no = pup.pup_number
+    aliases:
+      mother: otters
+      pup: otters
+    cardinality: one-to-many
+    description: Links a female otter to her dependent pup's own record.
+```
+
+Within a `join`, a name before the `.` resolves first as an alias declared by that relationship, then as a table name. An alias is scoped to the relationship that declares it, and it must not have the same name as a table in the dictionary. Every alias must name a table that exists, and every alias declared should be used by the join. Self-joins must use aliases.
+
+Prefer aliases that name the role a side plays (`mother`/`pup`, `manager`/`report`) over positional names like `left`/`right`; they make the join expression readable on its own.
+
+Aliases are also allowed, but not required, when two tables are joined more than once and each join means something different. Naming the roles says which is which:
+
+```yaml
+relationships:
+  - join: flights.origin = origin_airport.faa
+    aliases: {origin_airport: airports}
+    cardinality: many-to-one
+  - join: flights.dest = dest_airport.faa
+    aliases: {dest_airport: airports}
+    cardinality: many-to-one
 ```
 
 ## Glossary

--- a/site/validation.md
+++ b/site/validation.md
@@ -31,9 +31,9 @@ A validator reports two severities of problem: **errors** and **warnings**. The 
 | Code | Name | Sev | Description |
 |------|------|-----|-------------|
 | S01 | Unresolved foreign key | E | A `foreign_key` column has no `relationships` entry pointing it at a `primary_key` column. |
-| S02 | Unknown table | E | A relationship references a table that is not defined in `tables`. |
+| S02 | Unknown table | E | A relationship references a table that is not defined in `tables`, either directly in its `join` or as the target of an `aliases` entry. |
 | S03 | Unknown column | E | A relationship references a column that does not exist on its table. |
-| S04 | Invalid join | E | A `join` expression fails to parse, or references neither one (self-join) nor two tables. |
+| S04 | Invalid join | E | A `join` expression fails to parse, or references more than two tables. |
 | S05 | Unresolved conflict column | E | A name in `conflicts` is not a column on both sides of the join. |
 | S06 | Inconsistent cardinality | E | The declared cardinality is inconsistent with the constraints on the joined columns (e.g. `one-to-many` whose "one" side is not `primary_key` or `unique`). |
 | S07 | Wrong representation key | E | A column's data representation key is absent or wrong for its type (`enum` → `values`; `number(ordinal)`, `number(quantity)`, `date`, `datetime` → `range`; otherwise → `examples`). A `boolean` column must carry none of `values`, `range`, or `examples`. |
@@ -54,6 +54,9 @@ A validator reports two severities of problem: **errors** and **warnings**. The 
 | S22 | Empty column selection | W | A `COLUMNS('<regex>')` in an `assert` expression matches no columns on the table (likely a typo — the assertion would hold vacuously). |
 | S23 | Untyped column in an expression | E | An `assert` expression uses a column listed by name only, with no declared `type`, somewhere its type matters, so the expression can't be checked. Declaring the column's `type` fixes it. Operands whose type is never consulted (`IS NULL`, `IS NOT NULL`) are exempt. |
 | S24 | Invalid enum values | E | An `enum`'s `values` are not a non-empty set of strings: they are empty (`[]` or `{}`), so nothing is permitted, or a value is not a string — a number, a boolean, null, or a nested list/map. A category that reads as a number or a boolean has to be quoted to be a string (`'1'`, `'-9'`, `'true'`). Both forms are checked: the list items, and the keys of the map form. |
+| S25 | Unaliased self-join | E | Both sides of a `join` denote the same rows: the same name appears on both sides, or both sides resolve to the same table without each being a distinct alias. A self-join must name each side with its own `aliases` entry. |
+| S26 | Alias shadows table | E | An `aliases` key has the same name as a table in `tables`, so a name in the `join` could be read either way. |
+| S27 | Unused alias | W | An `aliases` entry is declared but never referenced by the relationship's `join`. |
 
 : {tbl-colwidths="[7,23,5,65]"}
 


### PR DESCRIPTION
Fixes #136.

A relationship's `join` can now declare `aliases`, a per-relationship map from alias to table name, giving each side of the join its own name:

```yaml
relationships:
  - join: mother.otter_no = pup.pup_number
    aliases:
      mother: otters
      pup: otters
    cardinality: one-to-many
```

Within a `join`, a name before the `.` resolves first as an alias of that relationship, then as a table.

## Why self-joins need this

Two separate problems with `otters.otter_no = otters.pup_number`:

1. It reads as a condition on a single row (`WHERE otter_no = pup_number`), not a join between two row sets.
2. It can't express a multi-conjunct self-join — an interval overlap within one table has no way to say which occurrence of the table in the second conjunct is the same row as which in the first. That's cross-conjunct identity, which needs a name; positional left/right can't carry it.

So both sides of a self-join must now be aliased. Aliases stay optional elsewhere, where they name the role a table plays rather than telling two sides apart — two tables joined more than once (origin/destination airports, role-playing date dimensions).

## Checks

| Code | Sev | |
|---|---|---|
| S25 | E | Unaliased self-join. Fires when both sides denote the same rows: one name on both sides, or two names resolving to one table without each being an alias — so aliasing only half the join doesn't slip through. Carries a hint with the concrete `aliases:` block to write. |
| S26 | E | An alias has the same name as a table. |
| S27 | W | An alias is declared but never used by the `join`. |

S02 now also covers an alias pointing at an undefined table, reported on the alias rather than the join. S04 no longer admits a one-table join, since that case belongs to S25.

## Notes

- The join grammar is untouched — aliases changed only what an identifier resolves to. Every consumer of a join's table name now goes through `Relationship::resolve`, including `resolve_foreign_key`, so a foreign key resolves through an alias.
- S05 dedups by *resolved* table, so a conflict missing from an aliased self-join reads "not a column of `otters`" rather than naming both aliases.
- `s06-self-join-one-to-many.yaml` was rewritten with aliases; otherwise it would report S25 alongside S06 and muddy that snapshot.
- `site/examples/otters.yaml` now fails S25 (it already failed S24 on unquoted enum values) — to fix upstream at hadley/otters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
