### PR TITLE
Allow backtick-quoted names in expressions

### DIFF
--- a/crates/data-dict/src/assert_expr.rs
+++ b/crates/data-dict/src/assert_expr.rs
@@ -21,14 +21,19 @@
 //! cmp         := "=" | "!=" | "<>" | "<" | "<=" | ">" | ">="
 //! literal     := number | string | "TRUE" | "FALSE" | "NULL"
 //! funcall     := IDENT "(" (expr ("," expr)*)? ")"   // incl. NOW(), interval(n, unit)
-//! columns     := "COLUMNS" "(" ("*" | string | "[" IDENT ("," IDENT)* "]") ")"
+//! columns     := "COLUMNS" "(" ("*" | string | "[" column ("," column)* "]") ")"
 //! case        := "CASE" ("WHEN" expr "THEN" expr)+ ("ELSE" expr)? "END"
+//! column      := IDENT | QUOTED
 //! IDENT       := [A-Za-z_][A-Za-z0-9_]*
+//! QUOTED      := "`" ( [^`] | "``" )+ "`"
 //! ```
 //!
 //! Keywords and function names are matched case-insensitively; column
 //! identifiers are preserved verbatim (case-sensitive, matched against the
-//! table). String literals are single-quoted, doubling a quote to embed one.
+//! table). A column whose name isn't an `IDENT`, or which collides with a
+//! reserved word, is written in backticks, doubling a backtick to embed one;
+//! quoting affects only how the name is read, never how it is matched. String
+//! literals are single-quoted, doubling a quote to embed one.
 //! Every node records the byte offsets it spans within the input so diagnostics
 //! can point at the failing token, exactly as [`crate::join_expr`] does.
 //!
@@ -464,6 +469,10 @@ impl<'a> Parser<'a> {
                 })
             }
             Some(b'\'') => self.parse_string(),
+            Some(b'`') => {
+                let name = self.parse_quoted_name()?;
+                Ok(self.node(ExprKind::Column(name), start))
+            }
             Some(b) if b.is_ascii_digit() => self.parse_number(),
             Some(b) if b.is_ascii_alphabetic() || b == b'_' => self.parse_word_expr(),
             _ => Err(self.err("expected an expression")),
@@ -503,6 +512,51 @@ impl<'a> Parser<'a> {
             start,
             end: self.pos,
         })
+    }
+
+    /// Parse a backtick-quoted column name, leaving `self.pos` after the
+    /// closing backtick. Errors point at the opening backtick, the token the
+    /// reader has to fix.
+    fn parse_quoted_name(&mut self) -> Result<String, ParseError> {
+        let start = self.pos;
+        debug_assert_eq!(self.peek(), Some(b'`'));
+        self.pos += 1;
+        let mut name = String::new();
+        loop {
+            match self.peek() {
+                None => {
+                    return Err(ParseError {
+                        message: "unterminated quoted name".into(),
+                        at: start,
+                    });
+                }
+                Some(b'`') => {
+                    // A doubled backtick is a literal backtick; a lone one ends it.
+                    if self.src.get(self.pos + 1) == Some(&b'`') {
+                        name.push('`');
+                        self.pos += 2;
+                    } else {
+                        self.pos += 1;
+                        break;
+                    }
+                }
+                Some(_) => {
+                    let ch_start = self.pos;
+                    self.advance_char();
+                    name.push_str(
+                        std::str::from_utf8(&self.src[ch_start..self.pos])
+                            .expect("input is valid utf-8"),
+                    );
+                }
+            }
+        }
+        if name.is_empty() {
+            return Err(ParseError {
+                message: "empty quoted name".into(),
+                at: start,
+            });
+        }
+        Ok(name)
     }
 
     fn advance_char(&mut self) {
@@ -659,13 +713,11 @@ impl<'a> Parser<'a> {
                 loop {
                     self.skip_ws();
                     let n_start = self.pos;
-                    if !self
-                        .peek()
-                        .is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
-                    {
-                        return Err(self.err("expected a column name"));
-                    }
-                    let name = self.read_word();
+                    let name = match self.peek() {
+                        Some(b'`') => self.parse_quoted_name()?,
+                        Some(b) if b.is_ascii_alphabetic() || b == b'_' => self.read_word(),
+                        _ => return Err(self.err("expected a column name")),
+                    };
                     names.push(Named {
                         name,
                         start: n_start,
@@ -1558,6 +1610,82 @@ mod tests {
         ));
         parse("COLUMNS('q[4-8]') IS NOT NULL");
         parse("COLUMNS([a, b, c]) IS NOT NULL");
+    }
+
+    #[test]
+    fn quoted_column_names() {
+        let e = parse("`creation date` IS NOT NULL");
+        let ExprKind::IsNull { operand, .. } = &e.root.kind else {
+            panic!()
+        };
+        assert!(matches!(&operand.kind, ExprKind::Column(c) if c == "creation date"));
+    }
+
+    #[test]
+    fn quoted_column_name_may_be_a_reserved_word() {
+        let e = parse("`end` >= `start`");
+        let ExprKind::Compare { lhs, rhs, .. } = &e.root.kind else {
+            panic!()
+        };
+        assert!(matches!(&lhs.kind, ExprKind::Column(c) if c == "end"));
+        assert!(matches!(&rhs.kind, ExprKind::Column(c) if c == "start"));
+    }
+
+    #[test]
+    fn quoted_column_name_holds_any_character() {
+        for (src, name) in [
+            ("`a``b` IS NULL", "a`b"),
+            ("`a.b` IS NULL", "a.b"),
+            ("`café` IS NULL", "café"),
+            ("`LENGTH(x)` IS NULL", "LENGTH(x)"),
+        ] {
+            let e = parse(src);
+            let ExprKind::IsNull { operand, .. } = &e.root.kind else {
+                panic!("{src}")
+            };
+            assert!(
+                matches!(&operand.kind, ExprKind::Column(c) if c == name),
+                "{src}"
+            );
+        }
+    }
+
+    #[test]
+    fn quoted_column_span_covers_the_backticks() {
+        let src = "`a b` IS NULL";
+        let e = parse(src);
+        let ExprKind::IsNull { operand, .. } = &e.root.kind else {
+            panic!()
+        };
+        assert_eq!(&src[operand.start..operand.end], "`a b`");
+    }
+
+    #[test]
+    fn quoted_column_in_columns_list() {
+        let e = parse("COLUMNS([`creation date`, b]) IS NOT NULL");
+        let ExprKind::IsNull { operand, .. } = &e.root.kind else {
+            panic!()
+        };
+        let ExprKind::Columns(ColumnsSelector::List(names)) = &operand.kind else {
+            panic!("expected a list selector")
+        };
+        assert_eq!(
+            names.iter().map(|n| n.name.as_str()).collect::<Vec<_>>(),
+            ["creation date", "b"]
+        );
+    }
+
+    #[test]
+    fn rejects_unterminated_quoted_name() {
+        let err = AssertExpr::parse("`a b IS NULL").unwrap_err();
+        assert!(err.message.contains("unterminated"));
+        assert_eq!(err.at, 0);
+    }
+
+    #[test]
+    fn rejects_empty_quoted_name() {
+        let err = AssertExpr::parse("`` IS NULL").unwrap_err();
+        assert!(err.message.contains("empty"));
     }
 
     #[test]

--- a/crates/data-dict/src/assert_expr.rs
+++ b/crates/data-dict/src/assert_expr.rs
@@ -161,12 +161,7 @@ pub enum CmpOp {
     Ge,
 }
 
-#[derive(Debug, Clone)]
-pub struct ParseError {
-    pub message: String,
-    /// Byte offset of the failing token (or end-of-string) within the input.
-    pub at: usize,
-}
+pub use crate::expr_lex::ParseError;
 
 impl AssertExpr {
     pub fn parse(input: &str) -> Result<AssertExpr, ParseError> {
@@ -470,7 +465,7 @@ impl<'a> Parser<'a> {
             }
             Some(b'\'') => self.parse_string(),
             Some(b'`') => {
-                let name = self.parse_quoted_name()?;
+                let name = crate::expr_lex::parse_quoted_name(self.src, &mut self.pos)?;
                 Ok(self.node(ExprKind::Column(name), start))
             }
             Some(b) if b.is_ascii_digit() => self.parse_number(),
@@ -499,7 +494,7 @@ impl<'a> Parser<'a> {
                 }
                 Some(_) => {
                     let ch_start = self.pos;
-                    self.advance_char();
+                    crate::expr_lex::advance_char(self.src, &mut self.pos);
                     value.push_str(
                         std::str::from_utf8(&self.src[ch_start..self.pos])
                             .expect("input is valid utf-8"),
@@ -512,63 +507,6 @@ impl<'a> Parser<'a> {
             start,
             end: self.pos,
         })
-    }
-
-    /// Parse a backtick-quoted column name, leaving `self.pos` after the
-    /// closing backtick. Errors point at the opening backtick, the token the
-    /// reader has to fix.
-    fn parse_quoted_name(&mut self) -> Result<String, ParseError> {
-        let start = self.pos;
-        debug_assert_eq!(self.peek(), Some(b'`'));
-        self.pos += 1;
-        let mut name = String::new();
-        loop {
-            match self.peek() {
-                None => {
-                    return Err(ParseError {
-                        message: "unterminated quoted name".into(),
-                        at: start,
-                    });
-                }
-                Some(b'`') => {
-                    // A doubled backtick is a literal backtick; a lone one ends it.
-                    if self.src.get(self.pos + 1) == Some(&b'`') {
-                        name.push('`');
-                        self.pos += 2;
-                    } else {
-                        self.pos += 1;
-                        break;
-                    }
-                }
-                Some(_) => {
-                    let ch_start = self.pos;
-                    self.advance_char();
-                    name.push_str(
-                        std::str::from_utf8(&self.src[ch_start..self.pos])
-                            .expect("input is valid utf-8"),
-                    );
-                }
-            }
-        }
-        if name.is_empty() {
-            return Err(ParseError {
-                message: "empty quoted name".into(),
-                at: start,
-            });
-        }
-        Ok(name)
-    }
-
-    fn advance_char(&mut self) {
-        // Step over one whole UTF-8 code point.
-        self.pos += 1;
-        while let Some(&b) = self.src.get(self.pos) {
-            if b & 0xC0 == 0x80 {
-                self.pos += 1;
-            } else {
-                break;
-            }
-        }
     }
 
     fn parse_number(&mut self) -> Result<Expr, ParseError> {
@@ -714,7 +652,7 @@ impl<'a> Parser<'a> {
                     self.skip_ws();
                     let n_start = self.pos;
                     let name = match self.peek() {
-                        Some(b'`') => self.parse_quoted_name()?,
+                        Some(b'`') => crate::expr_lex::parse_quoted_name(self.src, &mut self.pos)?,
                         Some(b) if b.is_ascii_alphabetic() || b == b'_' => self.read_word(),
                         _ => return Err(self.err("expected a column name")),
                     };

--- a/crates/data-dict/src/expr_lex.rs
+++ b/crates/data-dict/src/expr_lex.rs
@@ -1,0 +1,65 @@
+//! Lexical pieces shared by the expression parsers in [`crate::assert_expr`]
+//! and [`crate::join_expr`].
+
+#[derive(Debug, Clone)]
+pub struct ParseError {
+    pub message: String,
+    /// Byte offset of the failing token (or end-of-string) within the input.
+    pub at: usize,
+}
+
+/// Parse a backtick-quoted name with `pos` at the opening backtick, leaving it
+/// after the closing backtick. Errors point at the opening backtick, the token
+/// the reader has to fix.
+pub(crate) fn parse_quoted_name(src: &[u8], pos: &mut usize) -> Result<String, ParseError> {
+    let start = *pos;
+    debug_assert_eq!(src.get(start), Some(&b'`'));
+    *pos += 1;
+    let mut name = String::new();
+    loop {
+        match src.get(*pos) {
+            None => {
+                return Err(ParseError {
+                    message: "unterminated quoted name".into(),
+                    at: start,
+                });
+            }
+            Some(b'`') => {
+                // A doubled backtick is a literal backtick; a lone one ends it.
+                if src.get(*pos + 1) == Some(&b'`') {
+                    name.push('`');
+                    *pos += 2;
+                } else {
+                    *pos += 1;
+                    break;
+                }
+            }
+            Some(_) => {
+                let ch_start = *pos;
+                advance_char(src, pos);
+                name.push_str(
+                    std::str::from_utf8(&src[ch_start..*pos]).expect("input is valid utf-8"),
+                );
+            }
+        }
+    }
+    if name.is_empty() {
+        return Err(ParseError {
+            message: "empty quoted name".into(),
+            at: start,
+        });
+    }
+    Ok(name)
+}
+
+/// Step over one whole UTF-8 code point.
+pub(crate) fn advance_char(src: &[u8], pos: &mut usize) {
+    *pos += 1;
+    while let Some(&b) = src.get(*pos) {
+        if b & 0xC0 == 0x80 {
+            *pos += 1;
+        } else {
+            break;
+        }
+    }
+}

--- a/crates/data-dict/src/join_expr.rs
+++ b/crates/data-dict/src/join_expr.rs
@@ -6,13 +6,16 @@
 //! ```text
 //! join     := conjunct ("AND" conjunct)*
 //! conjunct := qcol op qcol
-//! qcol     := IDENT "." IDENT
+//! qcol     := name "." name
 //! op       := "=" | "==" | ">=" | "<=" | ">" | "<"
+//! name     := IDENT | QUOTED
 //! IDENT    := [A-Za-z_][A-Za-z0-9_]*
+//! QUOTED   := "`" ( [^`] | "``" )+ "`"
 //! ```
 //!
 //! `AND` is matched case-insensitively. Whitespace is permitted between
-//! tokens. The parser tracks byte offsets within the input string so we can
+//! tokens. Each side of the `.` is quoted independently, so a name that isn't
+//! an `IDENT` stays referenceable; a `.` inside backticks is part of the name. The parser tracks byte offsets within the input string so we can
 //! point diagnostics at the failing token.
 
 #[derive(Debug, Clone)]
@@ -158,6 +161,7 @@ impl<'a> Parser<'a> {
     fn parse_ident(&mut self) -> Result<String, ParseError> {
         let start = self.pos;
         match self.peek() {
+            Some(b'`') => return self.parse_quoted_name(),
             Some(b) if b.is_ascii_alphabetic() || b == b'_' => self.pos += 1,
             _ => return Err(self.err("expected identifier")),
         }
@@ -171,6 +175,63 @@ impl<'a> Parser<'a> {
         Ok(std::str::from_utf8(&self.src[start..self.pos])
             .expect("identifier bytes are ASCII")
             .to_string())
+    }
+
+    /// Parse a backtick-quoted table or column name, leaving `self.pos` after
+    /// the closing backtick. Errors point at the opening backtick, the token
+    /// the reader has to fix.
+    fn parse_quoted_name(&mut self) -> Result<String, ParseError> {
+        let start = self.pos;
+        debug_assert_eq!(self.peek(), Some(b'`'));
+        self.pos += 1;
+        let mut name = String::new();
+        loop {
+            match self.peek() {
+                None => {
+                    return Err(ParseError {
+                        message: "unterminated quoted name".into(),
+                        at: start,
+                    });
+                }
+                Some(b'`') => {
+                    // A doubled backtick is a literal backtick; a lone one ends it.
+                    if self.src.get(self.pos + 1) == Some(&b'`') {
+                        name.push('`');
+                        self.pos += 2;
+                    } else {
+                        self.pos += 1;
+                        break;
+                    }
+                }
+                Some(_) => {
+                    let ch_start = self.pos;
+                    self.advance_char();
+                    name.push_str(
+                        std::str::from_utf8(&self.src[ch_start..self.pos])
+                            .expect("input is valid utf-8"),
+                    );
+                }
+            }
+        }
+        if name.is_empty() {
+            return Err(ParseError {
+                message: "empty quoted name".into(),
+                at: start,
+            });
+        }
+        Ok(name)
+    }
+
+    /// Step over one whole UTF-8 code point.
+    fn advance_char(&mut self) {
+        self.pos += 1;
+        while let Some(&b) = self.src.get(self.pos) {
+            if b & 0xC0 == 0x80 {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
     }
 
     fn parse_op(&mut self) -> Result<JoinOp, ParseError> {
@@ -267,6 +328,41 @@ mod tests {
         let j = parse("food.fdc_id == food_nutrient.fdc_id");
         assert_eq!(j.conjuncts.len(), 1);
         assert_eq!(j.conjuncts[0].op, JoinOp::Eq);
+    }
+
+    #[test]
+    fn quoted_names() {
+        let j = parse("`other studies`.`creation date` = study.id");
+        assert_eq!(j.conjuncts[0].lhs.table, "other studies");
+        assert_eq!(j.conjuncts[0].lhs.column, "creation date");
+        assert_eq!(j.conjuncts[0].rhs.table, "study");
+    }
+
+    #[test]
+    fn quoted_name_holds_dots_and_backticks() {
+        let j = parse("`a.b`.`c``d` = t.x");
+        assert_eq!(j.conjuncts[0].lhs.table, "a.b");
+        assert_eq!(j.conjuncts[0].lhs.column, "c`d");
+    }
+
+    #[test]
+    fn quoted_name_spans_cover_the_backticks() {
+        let j = parse("`a b`.c = t.x");
+        let lhs = &j.conjuncts[0].lhs;
+        assert_eq!(&"`a b`.c = t.x"[lhs.start..lhs.end], "`a b`.c");
+    }
+
+    #[test]
+    fn rejects_unterminated_quoted_name() {
+        let err = JoinExpr::parse("`a b.c = t.x").unwrap_err();
+        assert!(err.message.contains("unterminated"));
+        assert_eq!(err.at, 0);
+    }
+
+    #[test]
+    fn rejects_empty_quoted_name() {
+        let err = JoinExpr::parse("t.`` = t.x").unwrap_err();
+        assert!(err.message.contains("empty"));
     }
 
     #[test]

--- a/crates/data-dict/src/join_expr.rs
+++ b/crates/data-dict/src/join_expr.rs
@@ -48,13 +48,7 @@ pub enum JoinOp {
     Lt,
 }
 
-#[derive(Debug, Clone)]
-pub struct ParseError {
-    pub message: String,
-    /// Byte offset of the failing token (or end-of-string) within the join
-    /// expression.
-    pub at: usize,
-}
+pub use crate::expr_lex::ParseError;
 
 impl JoinExpr {
     pub fn parse(input: &str) -> Result<JoinExpr, ParseError> {
@@ -161,7 +155,7 @@ impl<'a> Parser<'a> {
     fn parse_ident(&mut self) -> Result<String, ParseError> {
         let start = self.pos;
         match self.peek() {
-            Some(b'`') => return self.parse_quoted_name(),
+            Some(b'`') => return crate::expr_lex::parse_quoted_name(self.src, &mut self.pos),
             Some(b) if b.is_ascii_alphabetic() || b == b'_' => self.pos += 1,
             _ => return Err(self.err("expected identifier")),
         }
@@ -175,63 +169,6 @@ impl<'a> Parser<'a> {
         Ok(std::str::from_utf8(&self.src[start..self.pos])
             .expect("identifier bytes are ASCII")
             .to_string())
-    }
-
-    /// Parse a backtick-quoted table or column name, leaving `self.pos` after
-    /// the closing backtick. Errors point at the opening backtick, the token
-    /// the reader has to fix.
-    fn parse_quoted_name(&mut self) -> Result<String, ParseError> {
-        let start = self.pos;
-        debug_assert_eq!(self.peek(), Some(b'`'));
-        self.pos += 1;
-        let mut name = String::new();
-        loop {
-            match self.peek() {
-                None => {
-                    return Err(ParseError {
-                        message: "unterminated quoted name".into(),
-                        at: start,
-                    });
-                }
-                Some(b'`') => {
-                    // A doubled backtick is a literal backtick; a lone one ends it.
-                    if self.src.get(self.pos + 1) == Some(&b'`') {
-                        name.push('`');
-                        self.pos += 2;
-                    } else {
-                        self.pos += 1;
-                        break;
-                    }
-                }
-                Some(_) => {
-                    let ch_start = self.pos;
-                    self.advance_char();
-                    name.push_str(
-                        std::str::from_utf8(&self.src[ch_start..self.pos])
-                            .expect("input is valid utf-8"),
-                    );
-                }
-            }
-        }
-        if name.is_empty() {
-            return Err(ParseError {
-                message: "empty quoted name".into(),
-                at: start,
-            });
-        }
-        Ok(name)
-    }
-
-    /// Step over one whole UTF-8 code point.
-    fn advance_char(&mut self) {
-        self.pos += 1;
-        while let Some(&b) = self.src.get(self.pos) {
-            if b & 0xC0 == 0x80 {
-                self.pos += 1;
-            } else {
-                break;
-            }
-        }
     }
 
     fn parse_op(&mut self) -> Result<JoinOp, ParseError> {

--- a/crates/data-dict/src/lib.rs
+++ b/crates/data-dict/src/lib.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 pub mod assert_expr;
+mod expr_lex;
 pub mod join_expr;
 pub mod lower;
 pub mod model;

--- a/crates/data-dict/tests/fixtures/spec/quoted-names-ok.yaml
+++ b/crates/data-dict/tests/fixtures/spec/quoted-names-ok.yaml
@@ -1,0 +1,41 @@
+# expected: validates cleanly. Names that aren't plain identifiers — a space in
+# `other studies`/`study id`, and a column called `end`, a reserved word — are
+# referenced from the `join` and from an assertion in backticks. The quotes
+# change how the names are read, not how they are matched.
+
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+
+tables:
+  - name: study
+    columns:
+      - name: id
+        type: number(id)
+        constraints: [primary_key]
+        description: Study id.
+        examples: [1, 2, 3, 4, 5]
+
+  - name: other studies
+    columns:
+      - name: study id
+        type: number(id)
+        constraints: [foreign_key]
+        description: The study this one follows up.
+        examples: [1, 2, 3, 4, 5]
+      - name: creation date
+        type: date
+        description: When the record was created.
+        range: [2000-01-01, 2030-01-01]
+      - name: end
+        type: date
+        description: When the study ended.
+        range: [2000-01-01, 2030-01-01]
+    constraints:
+      - assert: '`creation date` <= `end`'
+        description: A study can't be created after it ends.
+      - assert: COLUMNS([`creation date`, `end`]) IS NOT NULL
+
+relationships:
+  - join: '`other studies`.`study id` = study.id'
+    cardinality: many-to-one
+    description: Each follow-up names the study it follows up.

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -460,6 +460,13 @@ fn s06_self_join_one_to_many() {
     assert_snapshot!(failing_diagnostic("spec/s06-self-join-one-to-many.yaml"));
 }
 
+// Names that aren't plain identifiers are referenced from a `join` in
+// backticks, so S02/S03 resolve them like any other name.
+#[test]
+fn quoted_names_ok() {
+    assert_valid(fixture("spec/quoted-names-ok.yaml"));
+}
+
 // --- aliases (S25/S26/S27) -----------------------------------------------
 
 #[test]
@@ -1259,6 +1266,55 @@ fn constraints_s20_unknown_column_in_columns_list() {
               - assert: COLUMNS([a, missing]) IS NOT NULL
     "});
     diagnostic.assert_contains(&["S20", "`missing`"]);
+}
+
+// Backticks are optional on a name that doesn't need them: a quoted name is
+// matched exactly like a bare one.
+#[test]
+fn constraints_quoting_does_not_change_matching() {
+    assert_valid_dict(indoc! {"
+        tables:
+          - name: t
+            columns:
+              - name: qty
+                type: number
+                examples: [1, 2]
+                constraints:
+                  - assert: '`qty` > 0'
+    "});
+}
+
+// S20: a quoted name resolves against the table like any other, so one that
+// isn't there is still unknown.
+#[test]
+fn constraints_s20_unknown_quoted_column() {
+    let diagnostic = failing_dict(indoc! {"
+        tables:
+          - name: t
+            columns:
+              - name: a
+                type: number
+                examples: [1, 2]
+            constraints:
+              - assert: '`no such column` IS NOT NULL'
+    "});
+    diagnostic.assert_contains(&["S20", "`no such column`", "not on this table"]);
+}
+
+// S19: a backtick left unclosed is a syntax error like any other.
+#[test]
+fn constraints_s19_unterminated_quoted_name() {
+    let diagnostic = failing_dict(indoc! {"
+        tables:
+          - name: t
+            columns:
+              - name: a
+                type: number
+                examples: [1, 2]
+            constraints:
+              - assert: '`a IS NOT NULL'
+    "});
+    diagnostic.assert_contains(&["S19", "unterminated quoted name"]);
 }
 
 // S21: a type mismatch — a numeric length compared as if the column were a

--- a/site/expressions.md
+++ b/site/expressions.md
@@ -18,7 +18,7 @@ tables:
 
 An expression is always written against the columns of one table: bare names are that table's column names, and an expression on a column sees every other column too. So the two constraints above differ in where they're written, not in what they can say — a column constraint sits next to the column it's mostly about, and a table constraint is the natural home for a rule that spans columns.
 
-This page is the reference for the language. It covers [how an expression is evaluated](#evaluation), [truth and null](#truth-and-null), the [types](#types) values carry, the [literals](#literals), [operators](#operators), and [functions](#functions) available, [`COLUMNS(...)`](#selecting-multiple-columns) for applying one predicate to many columns, the [type rules](#type-checking) a validator enforces, and the [grammar](#grammar).
+This page is the reference for the language. It covers [how an expression is evaluated](#evaluation), [truth and null](#truth-and-null), the [types](#types) values carry, how [columns are referred to](#column-references), the [literals](#literals), [operators](#operators), and [functions](#functions) available, [`COLUMNS(...)`](#selecting-multiple-columns) for applying one predicate to many columns, the [type rules](#type-checking) a validator enforces, and the [grammar](#grammar).
 
 ## Evaluation
 
@@ -60,6 +60,26 @@ An unknown type is only a problem where a type is actually needed. `IS NULL` and
 `NULL` is the one genuinely typeless thing in the language, and stays compatible with every type.
 
 The `number` measures (`number(id)`, `number(ordinal)`, `number(quantity)`) and a `datetime`'s `time_zone` do not affect type checking: all three measures are just `number`, and a `datetime` is a `datetime` whatever zone it declares.
+
+## Column references
+
+A name in an expression refers to a column of the table. Written bare, it must be a plain identifier: a letter or `_`, followed by letters, digits, or `_`.
+
+A name of any other shape — one containing a space or punctuation, one starting with a digit, or one that collides with a [reserved word](#grammar) — is written between backticks:
+
+```yaml
+constraints:
+  - assert: '`creation date` <= NOW()'
+  - assert: LENGTH(`postal code`) <= 10
+```
+
+The first expression is quoted in YAML and the second isn't, because a backtick is reserved as the first character of a plain YAML scalar. Only that position is affected: an expression that merely contains a backtick needs no YAML quotes.
+
+A backtick-quoted name may contain any character; double a backtick to include one, so ``` `a``b` ``` refers to the column named ``a`b``. An empty or unterminated quoted name is a syntax error.
+
+Quoting changes how a name is *read*, never how it is *matched*: `` `postcode` `` and `postcode` are the same column, and both are matched exactly against the column names in the data, [case included](#evaluation). Quote whenever you like — a name that doesn't need backticks is free to have them.
+
+The same rules apply to a qualified name in a relationship's [`join`](spec.md#relationships), where each side of the `.` is quoted on its own — `` `other studies`.`creation date` ``, `` food.`category id` ``. A `.` between backticks is part of the name rather than a separator.
 
 ## Literals
 
@@ -285,6 +305,8 @@ To apply the same predicate to a group of columns without repeating it, use a `C
 
 : {tbl-colwidths="[30,70]"}
 
+Names in the list are [written like any other column reference](#column-references), backticks included where they're needed: ``COLUMNS([`creation date`, updated_at])``. The regex form matches against the plain name, without them.
+
 The regex is an [RE2](https://github.com/google/re2/wiki/Syntax) expression matched **unanchored** (a partial match, as in DuckDB), so `COLUMNS('q')` selects every column whose name contains a `q`; anchor it with `^`/`$` to match the whole name. This is the one place a regex is unanchored — `SIMILAR TO` anchors.
 
 A `COLUMNS(...)` node stands in for a column reference, and the expression around it is evaluated once per selected column. The result is true only when it is true for **every** selected column — the per-column results are combined with `AND`.
@@ -355,9 +377,13 @@ primary        := literal | column | funcall | columns | case | "(" expr ")"
 cmp            := "=" | "!=" | "<>" | "<" | "<=" | ">" | ">="
 literal        := number | string | "TRUE" | "FALSE" | "NULL"
 funcall        := IDENT "(" (expr ("," expr)*)? ")"   // incl. NOW(), interval(n, unit)
-columns        := "COLUMNS" "(" ("*" | string | "[" IDENT ("," IDENT)* "]") ")"
+columns        := "COLUMNS" "(" ("*" | string | "[" column ("," column)* "]") ")"
 case           := "CASE" ("WHEN" expr "THEN" expr)+ ("ELSE" expr)? "END"
+column         := IDENT | QUOTED
 IDENT          := [A-Za-z_][A-Za-z0-9_]*
+QUOTED         := "`" ( [^`] | "``" )+ "`"
 ```
 
-The following words are reserved and can't be used as a bare column name: `AND`, `OR`, `NOT`, `IS`, `NULL`, `BETWEEN`, `IN`, `LIKE`, `SIMILAR`, `TO`, `WHEN`, `THEN`, `ELSE`, `END`, `TRUE`, `FALSE`.
+A function name is always an `IDENT`; only columns can be quoted.
+
+The following words are reserved and can't be used as a bare column name: `AND`, `OR`, `NOT`, `IS`, `NULL`, `BETWEEN`, `IN`, `LIKE`, `SIMILAR`, `TO`, `WHEN`, `THEN`, `ELSE`, `END`, `TRUE`, `FALSE`. A column named after one of them is still reachable [in backticks](#column-references).


### PR DESCRIPTION
A table or column could be declared with any non-empty name, but only a plain identifier (`[A-Za-z_][A-Za-z0-9_]*`) could be *referenced* from an assertion or a `join` — so a column called `creation date` was declarable and then unreachable, with no quoting syntax to bridge the gap.

Names of any other shape — containing a space or punctuation, starting with a digit, or colliding with a reserved word — now go in backticks:

```yaml
constraints:
  - assert: '`creation date` <= `end`'
relationships:
  - join: '`other studies`.`study id` = study.id'
```

A quoted name may hold any character, doubling a backtick to embed one. Each side of a join's `.` is quoted on its own, so a `.` between backticks is part of the name. Quoting changes only how a name is read, never how it's matched, so backticks are optional on a name that doesn't need them. Malformed quoting (unterminated, empty) lands on the existing S19/S04 rather than a new check code, so `validation.md` and `schema.yaml` are unchanged.

Backticks rather than SQL's `"` because `'…'` is already a string literal (and `COLUMNS('regex')` a regex), and because it matches the analytics mini-languages users come from — pandas `query()`, dplyr, Spark. One wrinkle documented in the spec: a backtick can't open a plain YAML scalar, so an expression *starting* with one needs YAML quotes; one merely containing a backtick doesn't.

Spec first: `site/expressions.md` gains a `Column references` section, plus grammar and `COLUMNS([...])` updates.

Tests: quoted names, reserved-word names, embedded backtick/dot/non-ASCII, spans, and the unterminated/empty rejections in both parsers; `tests/fixtures/spec/quoted-names-ok.yaml` exercises the whole path through the CLI.

Fixes #148, #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)