### PR TITLE
Use https for the canonical $learn_more URL

### DIFF
--- a/crates/data-dict-cli/tests/snapshots/cli__multiple_diagnostics_json_output.snap
+++ b/crates/data-dict-cli/tests/snapshots/cli__multiple_diagnostics_json_output.snap
@@ -17,7 +17,7 @@ expression: "serde_json::to_string_pretty(&value).unwrap()"
       "message": "`$learn_more` is not set",
       "severity": "warning",
       "suggestion": {
-        "replacement": "$learn_more: http://data-dict.tidyverse.org/\n",
+        "replacement": "$learn_more: https://data-dict.tidyverse.org/\n",
         "title": "point readers to the spec"
       }
     },

--- a/crates/data-dict-cli/tests/snapshots/cli__multiple_diagnostics_text_output.snap
+++ b/crates/data-dict-cli/tests/snapshots/cli__multiple_diagnostics_text_output.snap
@@ -10,7 +10,7 @@ warning[S09]: A document should point readers to the spec with `$learn_more`.
   |
 help: point readers to the spec
   |
-2 + $learn_more: http://data-dict.tidyverse.org/
+2 + $learn_more: https://data-dict.tidyverse.org/
   |
 error[S07]: A `number(id)` column must describe its data with `examples`.
  --> <fixture>:9:15

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -29,7 +29,7 @@ use crate::problem::{Problem, ProblemKind, ProblemSet, Suggestion, subspan};
 use crate::{SourceContext, lower};
 
 /// The canonical documentation URL suggested for `$learn_more`.
-pub const LEARN_MORE_URL: &str = "http://data-dict.tidyverse.org/";
+pub const LEARN_MORE_URL: &str = "https://data-dict.tidyverse.org/";
 
 /// The spec version this validator implements, suggested for a missing `$version`.
 pub const SPEC_VERSION: &str = "0.1.0";

--- a/crates/data-dict/tests/snapshots/validate_spec__warn_missing_learn_more.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__warn_missing_learn_more.snap
@@ -11,5 +11,5 @@ LL | $version: 0.1.0
    |
 help: point readers to the spec
    |
-LL + $learn_more: http://data-dict.tidyverse.org/
+LL + $learn_more: https://data-dict.tidyverse.org/
    |

--- a/site/spec.md
+++ b/site/spec.md
@@ -7,7 +7,7 @@ A data dictionary has three kinds of top-level keys: `$`-prefixed metadata keys 
 The metadata keys are:
 
 * `$version` (required): the version of the `data-dict.yaml` spec the document conforms to. Currently `0.1.0`. While the spec is pre-1.0, breaking changes are expected, but once the spec stabilises at 1.0, breaking changes will always increment at least the minor version.
-* `$learn_more` (optional, but recommended): a URL where readers can learn about the `data-dict.yaml` format, so that people and tools meeting the file for the first time can find out what it is. Use <http://data-dict.tidyverse.org/>. Omitting it is valid, but a validator will emit a warning rather than an error (see [Validation](validation.md)).
+* `$learn_more` (optional, but recommended): a URL where readers can learn about the `data-dict.yaml` format, so that people and tools meeting the file for the first time can find out what it is. Use <https://data-dict.tidyverse.org/>. Omitting it is valid, but a validator will emit a warning rather than an error (see [Validation](validation.md)).
 
 The descriptive keys — `name`, `label`, `description`, and `details` — identify and document the dataset as a whole. All four are optional here, and work the same way at every level of the dictionary; see [Name, label, description & details](#name-label-description--details) for their full meaning. For the dataset, `name` is a terse identifier (e.g. `foodbank`) and `label` its human-readable title.
 


### PR DESCRIPTION
Switches `LEARN_MORE_URL` (the URL suggested by the S09 fix and documented in the spec) from `http://` to `https://`, and updates the snapshots that render it.