### PR TITLE
Export definitions, with translations

### DIFF
--- a/crates/data-dict/src/assert_expr.rs
+++ b/crates/data-dict/src/assert_expr.rs
@@ -1193,71 +1193,175 @@ pub fn analyze(expr: &AssertExpr, env: &dyn CheckEnv, root: Root) -> (Ty, Shape,
     (ty, shape, cx.findings)
 }
 
+/// `f` on each direct child expression of `e`.
+fn each_child(e: &Expr, mut f: impl FnMut(&Expr)) {
+    match &e.kind {
+        ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Null
+        | ExprKind::Now
+        | ExprKind::Column(_)
+        | ExprKind::Columns(_) => {}
+        ExprKind::Neg(inner) | ExprKind::Not(inner) => f(inner),
+        ExprKind::IsNull { operand, .. } => f(operand),
+        ExprKind::Interval { n, .. } => f(n),
+        ExprKind::Arith { lhs, rhs, .. } | ExprKind::Compare { lhs, rhs, .. } => {
+            f(lhs);
+            f(rhs);
+        }
+        ExprKind::And(l, r) | ExprKind::Or(l, r) => {
+            f(l);
+            f(r);
+        }
+        ExprKind::Like {
+            operand, pattern, ..
+        }
+        | ExprKind::SimilarTo {
+            operand, pattern, ..
+        } => {
+            f(operand);
+            f(pattern);
+        }
+        ExprKind::Between {
+            operand, lo, hi, ..
+        } => {
+            f(operand);
+            f(lo);
+            f(hi);
+        }
+        ExprKind::In { operand, list, .. } => {
+            f(operand);
+            for item in list {
+                f(item);
+            }
+        }
+        ExprKind::Call { args, .. } => {
+            for a in args {
+                f(a);
+            }
+        }
+        ExprKind::Case { whens, els } => {
+            for (cond, result) in whens {
+                f(cond);
+                f(result);
+            }
+            if let Some(els) = els {
+                f(els);
+            }
+        }
+    }
+}
+
+/// `f` on each direct child expression of `e`, mutably.
+fn each_child_mut(e: &mut Expr, mut f: impl FnMut(&mut Expr)) {
+    match &mut e.kind {
+        ExprKind::Number(_)
+        | ExprKind::Str(_)
+        | ExprKind::Bool(_)
+        | ExprKind::Null
+        | ExprKind::Now
+        | ExprKind::Column(_)
+        | ExprKind::Columns(_) => {}
+        ExprKind::Neg(inner) | ExprKind::Not(inner) => f(inner),
+        ExprKind::IsNull { operand, .. } => f(operand),
+        ExprKind::Interval { n, .. } => f(n),
+        ExprKind::Arith { lhs, rhs, .. } | ExprKind::Compare { lhs, rhs, .. } => {
+            f(lhs);
+            f(rhs);
+        }
+        ExprKind::And(l, r) | ExprKind::Or(l, r) => {
+            f(l);
+            f(r);
+        }
+        ExprKind::Like {
+            operand, pattern, ..
+        }
+        | ExprKind::SimilarTo {
+            operand, pattern, ..
+        } => {
+            f(operand);
+            f(pattern);
+        }
+        ExprKind::Between {
+            operand, lo, hi, ..
+        } => {
+            f(operand);
+            f(lo);
+            f(hi);
+        }
+        ExprKind::In { operand, list, .. } => {
+            f(operand);
+            for item in list {
+                f(item);
+            }
+        }
+        ExprKind::Call { args, .. } => {
+            for a in args {
+                f(a);
+            }
+        }
+        ExprKind::Case { whens, els } => {
+            for (cond, result) in whens {
+                f(cond);
+                f(result);
+            }
+            if let Some(els) = els {
+                f(els);
+            }
+        }
+    }
+}
+
+/// `f` on every node of the tree rooted at `e`, pre-order.
+pub fn visit(e: &Expr, mut f: impl FnMut(&Expr)) {
+    fn walk(e: &Expr, f: &mut impl FnMut(&Expr)) {
+        f(e);
+        each_child(e, |c| walk(c, f));
+    }
+    walk(e, &mut f);
+}
+
+/// `f` on every node of the tree rooted at `e`, pre-order. The children of a
+/// node `f` returns `true` for are not visited — for when `f` replaced the
+/// node wholesale.
+pub fn visit_mut(e: &mut Expr, mut f: impl FnMut(&mut Expr) -> bool) {
+    fn walk(e: &mut Expr, f: &mut impl FnMut(&mut Expr) -> bool) {
+        if f(e) {
+            return;
+        }
+        each_child_mut(e, |c| {
+            walk(c, f);
+        });
+    }
+    walk(e, &mut f);
+}
+
 /// The first segment of every column path in `expr`: the names the expression
 /// resolves against the table's columns and definitions. Used to build the
 /// reference graph between a table's definitions.
 pub fn referenced_names(expr: &AssertExpr) -> Vec<String> {
-    fn walk(e: &Expr, names: &mut Vec<String>) {
-        match &e.kind {
-            ExprKind::Number(_)
-            | ExprKind::Str(_)
-            | ExprKind::Bool(_)
-            | ExprKind::Null
-            | ExprKind::Now
-            | ExprKind::Columns(_) => {}
-            ExprKind::Column(path) => names.push(path[0].clone()),
-            ExprKind::Neg(inner) | ExprKind::Not(inner) => walk(inner, names),
-            ExprKind::IsNull { operand, .. } => walk(operand, names),
-            ExprKind::Interval { n, .. } => walk(n, names),
-            ExprKind::Arith { lhs, rhs, .. } | ExprKind::Compare { lhs, rhs, .. } => {
-                walk(lhs, names);
-                walk(rhs, names);
-            }
-            ExprKind::And(l, r) | ExprKind::Or(l, r) => {
-                walk(l, names);
-                walk(r, names);
-            }
-            ExprKind::Like {
-                operand, pattern, ..
-            }
-            | ExprKind::SimilarTo {
-                operand, pattern, ..
-            } => {
-                walk(operand, names);
-                walk(pattern, names);
-            }
-            ExprKind::Between {
-                operand, lo, hi, ..
-            } => {
-                walk(operand, names);
-                walk(lo, names);
-                walk(hi, names);
-            }
-            ExprKind::In { operand, list, .. } => {
-                walk(operand, names);
-                for item in list {
-                    walk(item, names);
-                }
-            }
-            ExprKind::Call { args, .. } => {
-                for a in args {
-                    walk(a, names);
-                }
-            }
-            ExprKind::Case { whens, els } => {
-                for (cond, result) in whens {
-                    walk(cond, names);
-                    walk(result, names);
-                }
-                if let Some(els) = els {
-                    walk(els, names);
-                }
-            }
-        }
-    }
     let mut names = Vec::new();
-    walk(&expr.root, &mut names);
+    visit(&expr.root, |e| {
+        if let ExprKind::Column(path) = &e.kind {
+            names.push(path[0].clone());
+        }
+    });
     names
+}
+
+/// The number of `COLUMNS(...)` selections in `expr`. The checker allows at
+/// most one per expression, but a definition reference stands in for the
+/// definition's whole expression, so the count that matters for evaluation is
+/// taken after [`substitute_definitions`].
+pub fn columns_selection_count(expr: &AssertExpr) -> usize {
+    let mut count = 0;
+    visit(&expr.root, |e| {
+        if let ExprKind::Columns(_) = &e.kind {
+            count += 1;
+        }
+    });
+    count
 }
 
 /// `expr` with every reference to a definition in `defs` replaced by that
@@ -1270,106 +1374,19 @@ pub fn substitute_definitions(
     expr: &AssertExpr,
     defs: &std::collections::HashMap<String, AssertExpr>,
 ) -> AssertExpr {
-    fn walk(e: &Expr, defs: &std::collections::HashMap<String, AssertExpr>) -> Expr {
-        let kind = match &e.kind {
-            ExprKind::Column(path) if path.len() == 1 && defs.contains_key(&path[0]) => {
-                return defs[&path[0]].root.clone();
-            }
-            ExprKind::Number(_)
-            | ExprKind::Str(_)
-            | ExprKind::Bool(_)
-            | ExprKind::Null
-            | ExprKind::Now
-            | ExprKind::Column(_)
-            | ExprKind::Columns(_) => e.kind.clone(),
-            ExprKind::Neg(inner) => ExprKind::Neg(Box::new(walk(inner, defs))),
-            ExprKind::Not(inner) => ExprKind::Not(Box::new(walk(inner, defs))),
-            ExprKind::IsNull { operand, negated } => ExprKind::IsNull {
-                operand: Box::new(walk(operand, defs)),
-                negated: *negated,
-            },
-            ExprKind::Interval {
-                n,
-                unit,
-                unit_start,
-                unit_end,
-            } => ExprKind::Interval {
-                n: Box::new(walk(n, defs)),
-                unit: unit.clone(),
-                unit_start: *unit_start,
-                unit_end: *unit_end,
-            },
-            ExprKind::Arith { op, lhs, rhs } => ExprKind::Arith {
-                op: *op,
-                lhs: Box::new(walk(lhs, defs)),
-                rhs: Box::new(walk(rhs, defs)),
-            },
-            ExprKind::Compare { op, lhs, rhs } => ExprKind::Compare {
-                op: *op,
-                lhs: Box::new(walk(lhs, defs)),
-                rhs: Box::new(walk(rhs, defs)),
-            },
-            ExprKind::And(l, r) => ExprKind::And(Box::new(walk(l, defs)), Box::new(walk(r, defs))),
-            ExprKind::Or(l, r) => ExprKind::Or(Box::new(walk(l, defs)), Box::new(walk(r, defs))),
-            ExprKind::Like {
-                operand,
-                pattern,
-                negated,
-            } => ExprKind::Like {
-                operand: Box::new(walk(operand, defs)),
-                pattern: Box::new(walk(pattern, defs)),
-                negated: *negated,
-            },
-            ExprKind::SimilarTo {
-                operand,
-                pattern,
-                negated,
-            } => ExprKind::SimilarTo {
-                operand: Box::new(walk(operand, defs)),
-                pattern: Box::new(walk(pattern, defs)),
-                negated: *negated,
-            },
-            ExprKind::Between {
-                operand,
-                lo,
-                hi,
-                negated,
-            } => ExprKind::Between {
-                operand: Box::new(walk(operand, defs)),
-                lo: Box::new(walk(lo, defs)),
-                hi: Box::new(walk(hi, defs)),
-                negated: *negated,
-            },
-            ExprKind::In {
-                operand,
-                list,
-                negated,
-            } => ExprKind::In {
-                operand: Box::new(walk(operand, defs)),
-                list: list.iter().map(|item| walk(item, defs)).collect(),
-                negated: *negated,
-            },
-            ExprKind::Call { name, args } => ExprKind::Call {
-                name: name.clone(),
-                args: args.iter().map(|a| walk(a, defs)).collect(),
-            },
-            ExprKind::Case { whens, els } => ExprKind::Case {
-                whens: whens
-                    .iter()
-                    .map(|(cond, result)| (walk(cond, defs), walk(result, defs)))
-                    .collect(),
-                els: els.as_ref().map(|e| Box::new(walk(e, defs))),
-            },
-        };
-        Expr {
-            kind,
-            start: e.start,
-            end: e.end,
+    let mut expr = expr.clone();
+    visit_mut(&mut expr.root, |e| {
+        if let ExprKind::Column(path) = &e.kind
+            && path.len() == 1
+            && let Some(def) = defs.get(&path[0])
+        {
+            // Already expanded, so its own references need no visit.
+            *e = def.root.clone();
+            return true;
         }
-    }
-    AssertExpr {
-        root: walk(&expr.root, defs),
-    }
+        false
+    });
+    expr
 }
 
 struct Checker<'a> {

--- a/crates/data-dict/src/assert_expr.rs
+++ b/crates/data-dict/src/assert_expr.rs
@@ -1260,6 +1260,118 @@ pub fn referenced_names(expr: &AssertExpr) -> Vec<String> {
     names
 }
 
+/// `expr` with every reference to a definition in `defs` replaced by that
+/// definition's own expression. Only a bare name can reference a definition
+/// (a dotted path is a struct field), and `defs` holds only definitions whose
+/// names no column claims. For evaluation against data, where a referenced
+/// definition must become its expression; translation instead keeps the name
+/// for the consumer to substitute.
+pub fn substitute_definitions(
+    expr: &AssertExpr,
+    defs: &std::collections::HashMap<String, AssertExpr>,
+) -> AssertExpr {
+    fn walk(e: &Expr, defs: &std::collections::HashMap<String, AssertExpr>) -> Expr {
+        let kind = match &e.kind {
+            ExprKind::Column(path) if path.len() == 1 && defs.contains_key(&path[0]) => {
+                return defs[&path[0]].root.clone();
+            }
+            ExprKind::Number(_)
+            | ExprKind::Str(_)
+            | ExprKind::Bool(_)
+            | ExprKind::Null
+            | ExprKind::Now
+            | ExprKind::Column(_)
+            | ExprKind::Columns(_) => e.kind.clone(),
+            ExprKind::Neg(inner) => ExprKind::Neg(Box::new(walk(inner, defs))),
+            ExprKind::Not(inner) => ExprKind::Not(Box::new(walk(inner, defs))),
+            ExprKind::IsNull { operand, negated } => ExprKind::IsNull {
+                operand: Box::new(walk(operand, defs)),
+                negated: *negated,
+            },
+            ExprKind::Interval {
+                n,
+                unit,
+                unit_start,
+                unit_end,
+            } => ExprKind::Interval {
+                n: Box::new(walk(n, defs)),
+                unit: unit.clone(),
+                unit_start: *unit_start,
+                unit_end: *unit_end,
+            },
+            ExprKind::Arith { op, lhs, rhs } => ExprKind::Arith {
+                op: *op,
+                lhs: Box::new(walk(lhs, defs)),
+                rhs: Box::new(walk(rhs, defs)),
+            },
+            ExprKind::Compare { op, lhs, rhs } => ExprKind::Compare {
+                op: *op,
+                lhs: Box::new(walk(lhs, defs)),
+                rhs: Box::new(walk(rhs, defs)),
+            },
+            ExprKind::And(l, r) => ExprKind::And(Box::new(walk(l, defs)), Box::new(walk(r, defs))),
+            ExprKind::Or(l, r) => ExprKind::Or(Box::new(walk(l, defs)), Box::new(walk(r, defs))),
+            ExprKind::Like {
+                operand,
+                pattern,
+                negated,
+            } => ExprKind::Like {
+                operand: Box::new(walk(operand, defs)),
+                pattern: Box::new(walk(pattern, defs)),
+                negated: *negated,
+            },
+            ExprKind::SimilarTo {
+                operand,
+                pattern,
+                negated,
+            } => ExprKind::SimilarTo {
+                operand: Box::new(walk(operand, defs)),
+                pattern: Box::new(walk(pattern, defs)),
+                negated: *negated,
+            },
+            ExprKind::Between {
+                operand,
+                lo,
+                hi,
+                negated,
+            } => ExprKind::Between {
+                operand: Box::new(walk(operand, defs)),
+                lo: Box::new(walk(lo, defs)),
+                hi: Box::new(walk(hi, defs)),
+                negated: *negated,
+            },
+            ExprKind::In {
+                operand,
+                list,
+                negated,
+            } => ExprKind::In {
+                operand: Box::new(walk(operand, defs)),
+                list: list.iter().map(|item| walk(item, defs)).collect(),
+                negated: *negated,
+            },
+            ExprKind::Call { name, args } => ExprKind::Call {
+                name: name.clone(),
+                args: args.iter().map(|a| walk(a, defs)).collect(),
+            },
+            ExprKind::Case { whens, els } => ExprKind::Case {
+                whens: whens
+                    .iter()
+                    .map(|(cond, result)| (walk(cond, defs), walk(result, defs)))
+                    .collect(),
+                els: els.as_ref().map(|e| Box::new(walk(e, defs))),
+            },
+        };
+        Expr {
+            kind,
+            start: e.start,
+            end: e.end,
+        }
+    }
+    AssertExpr {
+        root: walk(&expr.root, defs),
+    }
+}
+
 struct Checker<'a> {
     env: &'a dyn CheckEnv,
     findings: Vec<Finding>,

--- a/crates/data-dict/src/assert_expr/ir.rs
+++ b/crates/data-dict/src/assert_expr/ir.rs
@@ -432,11 +432,11 @@ impl Lowerer<'_> {
             ExprKind::Bool(b) => lit(NodeKind::Bool(*b), Type::Bool, span),
             ExprKind::Null => lit(NodeKind::Null, Type::Any, span),
             ExprKind::Column(path) => {
-                let column = self.column_ref(path)?;
+                let (column, shape) = self.column_ref(path)?;
                 TypedExpr {
                     ty: column.ty,
                     kind: NodeKind::Column(column),
-                    shape: Shape::Row,
+                    shape,
                     span,
                 }
             }
@@ -721,16 +721,39 @@ impl Lowerer<'_> {
         })
     }
 
-    fn column_ref(&self, path: &[String]) -> Option<ColumnRef> {
-        let kind = if path.len() == 1 {
-            self.env.column(&path[0])?
-        } else {
-            self.env.field(path)?
-        };
-        Some(ColumnRef {
-            path: path.to_vec(),
-            ty: to_type(kind_to_ty(kind)),
-        })
+    fn column_ref(&self, path: &[String]) -> Option<(ColumnRef, Shape)> {
+        if path.len() > 1 {
+            let kind = self.env.field(path)?;
+            return Some((
+                ColumnRef {
+                    path: path.to_vec(),
+                    ty: to_type(kind_to_ty(kind)),
+                },
+                Shape::Row,
+            ));
+        }
+        match self.env.column(&path[0]) {
+            Some(kind) => Some((
+                ColumnRef {
+                    path: path.to_vec(),
+                    ty: to_type(kind_to_ty(kind)),
+                },
+                Shape::Row,
+            )),
+            // Not a column: a bare name may be a definition, rendered as a
+            // name with the definition's own type and shape for the consumer
+            // to substitute.
+            None => {
+                let def = self.env.definition(&path[0])?;
+                Some((
+                    ColumnRef {
+                        path: path.to_vec(),
+                        ty: to_type(def.ty),
+                    },
+                    def.shape,
+                ))
+            }
+        }
     }
 
     /// Record the expression's one `COLUMNS(...)` and the columns it picked out.

--- a/crates/data-dict/src/export.rs
+++ b/crates/data-dict/src/export.rs
@@ -19,14 +19,14 @@ use data_dict_parquet::{
     profile, profile_paths, render_scalar,
 };
 
-use crate::assert_expr::{self, ColumnsSelector, Expr, ExprKind};
+use crate::assert_expr::{self, ColumnsSelector, DefType, Expr, ExprKind, Ty};
 use crate::emit;
 use crate::model::{
-    Assertion, Cardinality, Column, Constraint, DataDict, Relationship, Representation, Scalar,
-    Spanned, Table, Version,
+    Assertion, Cardinality, Column, Constraint, DataDict, Definition, Relationship, Representation,
+    Scalar, Spanned, Table, Version,
 };
 use crate::problem::{ProblemKind, ProblemSet, Severity};
-use crate::validate_spec::TableEnv;
+use crate::validate_spec::{TableEnv, resolve_definitions};
 use crate::{load, validate_and_lower};
 
 /// The version of the export document format itself, carried as the
@@ -118,6 +118,8 @@ struct ExportTable {
     columns: Vec<ExportColumn>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     constraints: Vec<ExportAssertion>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    definitions: Vec<ExportDefinition>,
 }
 
 #[derive(Debug, Serialize)]
@@ -187,6 +189,37 @@ struct ExportAssertion {
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     columns: Vec<String>,
+    /// Other definitions of the same table the expression builds on.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    definitions: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    translations: Vec<ExportTranslation>,
+}
+
+/// A table-level definition: a named expression with its kind, value type,
+/// and references resolved. `kind` reads off the expression's type and shape,
+/// as the spec defines: a boolean row-level expression is a filter, an
+/// aggregate or constant a metric, anything else a derived value.
+#[derive(Debug, Serialize)]
+struct ExportDefinition {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<String>,
+    expression: String,
+    kind: &'static str,
+    /// The expression's value type; absent when it couldn't be resolved (a
+    /// definition whose expression failed to check, or one on a reference
+    /// cycle — both already spec errors).
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
+    value_type: Option<&'static str>,
+    columns: Vec<String>,
+    /// Other definitions of the same table the expression builds on.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    definitions: Vec<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     translations: Vec<ExportTranslation>,
 }
@@ -565,6 +598,8 @@ fn build_table(
     rows: Option<usize>,
     profiles: &mut TableProfiles,
 ) -> ExportTable {
+    let defs = resolve_definitions(table);
+    let referable = referable_definitions(table);
     ExportTable {
         name: table.name.value.clone(),
         label: table.label.as_ref().map(|s| s.value.clone()),
@@ -576,13 +611,35 @@ fn build_table(
             parquet: s.parquet.value.clone(),
         }),
         rows,
-        columns: build_columns(dict, table, &table.columns, &[], profiles),
+        columns: build_columns(dict, table, &table.columns, &[], &referable, profiles),
         constraints: table
             .constraints
             .iter()
-            .map(|a| build_assertion(a, table))
+            .map(|a| build_assertion(a, table, &referable))
+            .collect(),
+        definitions: table
+            .definitions
+            .iter()
+            .map(|d| build_definition(d, table, &defs, &referable))
             .collect(),
     }
+}
+
+/// The definitions a reference in one of `table`'s expressions may resolve
+/// to: the first of each non-empty name not claimed by a column (the
+/// collision is S32), with a parsed expression. Mirrors the referable set
+/// spec validation uses.
+fn referable_definitions(table: &Table) -> HashMap<&str, &Definition> {
+    let mut referable = HashMap::new();
+    for def in &table.definitions {
+        if !def.name.value.is_empty()
+            && table.column(&def.name.value).is_none()
+            && def.expr.is_some()
+        {
+            referable.entry(def.name.value.as_str()).or_insert(def);
+        }
+    }
+    referable
 }
 
 /// Build one level of the column tree. A column (or field) with no declared
@@ -592,12 +649,13 @@ fn build_columns(
     table: &Table,
     columns: &[Column],
     prefix: &[&str],
+    referable: &HashMap<&str, &Definition>,
     profiles: &mut TableProfiles,
 ) -> Vec<ExportColumn> {
     columns
         .iter()
         .filter(|col| col.col_type.is_some())
-        .map(|col| build_column(dict, table, col, prefix, profiles))
+        .map(|col| build_column(dict, table, col, prefix, referable, profiles))
         .collect()
 }
 
@@ -606,6 +664,7 @@ fn build_column(
     table: &Table,
     col: &Column,
     prefix: &[&str],
+    referable: &HashMap<&str, &Definition>,
     profiles: &mut TableProfiles,
 ) -> ExportColumn {
     let path: Vec<&str> = prefix
@@ -697,14 +756,62 @@ fn build_column(
         fields: col
             .fields
             .as_ref()
-            .map(|fields| build_columns(dict, table, fields, &path, profiles))
+            .map(|fields| build_columns(dict, table, fields, &path, referable, profiles))
             .unwrap_or_default(),
         assertions: col
             .assertions
             .iter()
-            .map(|a| build_assertion(a, table))
+            .map(|a| build_assertion(a, table, referable))
             .collect(),
         profile,
+    }
+}
+
+fn build_definition(
+    def: &Definition,
+    table: &Table,
+    defs: &HashMap<String, DefType>,
+    referable: &HashMap<&str, &Definition>,
+) -> ExportDefinition {
+    let mut columns = Vec::new();
+    let mut definitions = Vec::new();
+    let mut translations = Vec::new();
+    if let Some(expr) = &def.expr {
+        collect_columns(&expr.root, table, referable, &mut columns, &mut definitions);
+        translations = translate_expression(&expr.root, table, referable);
+    }
+    let resolved = defs.get(&def.name.value);
+    let kind = match resolved {
+        Some(DefType {
+            shape: assert_expr::Shape::Agg | assert_expr::Shape::Const,
+            ..
+        }) => "metric",
+        Some(DefType {
+            ty: Ty::Bool,
+            shape: assert_expr::Shape::Row,
+        }) => "filter",
+        _ => "derived",
+    };
+    let value_type = resolved.and_then(|d| match d.ty {
+        Ty::Number => Some("number"),
+        Ty::String => Some("string"),
+        Ty::Bool => Some("boolean"),
+        Ty::Date => Some("date"),
+        Ty::Datetime => Some("datetime"),
+        Ty::Interval => Some("interval"),
+        Ty::Struct | Ty::List | Ty::Any | Ty::Unknown => None,
+    });
+    ExportDefinition {
+        name: def.name.value.clone(),
+        label: def.label.clone(),
+        description: prose(&def.description),
+        details: prose(&def.details),
+        expression: def.text.value.clone(),
+        kind,
+        value_type,
+        columns,
+        definitions,
+        translations,
     }
 }
 
@@ -749,92 +856,151 @@ fn representation_labels(rep: &Representation) -> BTreeMap<String, String> {
         .collect()
 }
 
-fn build_assertion(assertion: &Assertion, table: &Table) -> ExportAssertion {
+fn build_assertion(
+    assertion: &Assertion,
+    table: &Table,
+    referable: &HashMap<&str, &Definition>,
+) -> ExportAssertion {
     let mut columns = Vec::new();
+    let mut definitions = Vec::new();
     let mut translations = Vec::new();
     if let Some(expr) = &assertion.expr {
-        collect_columns(&expr.root, table, &mut columns);
-        // The spec pass has already checked every assertion, so lowering only
-        // fails when export runs without it.
-        if let Some(ir) = assert_expr::lower(expr, &TableEnv::new(table)) {
-            for target in crate::translate::registry() {
-                translations.push(match emit::emit(target.as_ref(), &ir) {
-                    Ok(emitted) => ExportTranslation {
-                        target: target.name(),
-                        code: Some(emitted.code),
-                        error: None,
-                        notes: emitted.notes,
-                    },
-                    Err(unsupported) => ExportTranslation {
-                        target: target.name(),
-                        code: None,
-                        error: Some(format!(
-                            "{} is not supported: {}",
-                            unsupported.what, unsupported.why
-                        )),
-                        notes: Vec::new(),
-                    },
-                });
-            }
-        }
+        collect_columns(&expr.root, table, referable, &mut columns, &mut definitions);
+        translations = translate_expression(&expr.root, table, referable);
     }
     ExportAssertion {
         expression: assertion.text.value.clone(),
         description: prose(&assertion.description),
         columns,
+        definitions,
         translations,
     }
 }
 
-/// Collect every column (and struct field, dotted) `e` references into `out`,
-/// first-appearance order, deduplicated. A `COLUMNS(...)` selection expands to
-/// the table columns it matches, mirroring the S21/S22 checker — restricted to
-/// typed columns, since untyped ones are omitted from the export.
-fn collect_columns(e: &Expr, table: &Table, out: &mut Vec<String>) {
+/// One entry per target: the expression rendered in that target's language,
+/// or the reason the target refused. An expression that builds on another
+/// definition isn't translated — the client has the referenced definition's
+/// own translations (named by the `definitions` key) and composes them — so
+/// every target carries the reason instead. The spec pass has already
+/// checked every expression, so lowering only fails when export runs without
+/// it.
+fn translate_expression(
+    root: &Expr,
+    table: &Table,
+    referable: &HashMap<&str, &Definition>,
+) -> Vec<ExportTranslation> {
+    let expr = assert_expr::AssertExpr { root: root.clone() };
+    let refs: Vec<String> = assert_expr::referenced_names(&expr)
+        .into_iter()
+        .filter(|name| referable.contains_key(name.as_str()))
+        .collect();
+    if !refs.is_empty() {
+        return crate::translate::registry()
+            .iter()
+            .map(|target| ExportTranslation {
+                target: target.name(),
+                code: None,
+                error: Some(format!(
+                    "references the definition `{}`; compose it from that definition's own translation",
+                    refs.join("`, `")
+                )),
+                notes: Vec::new(),
+            })
+            .collect();
+    }
+    let mut translations = Vec::new();
+    if let Some(ir) = assert_expr::lower(&expr, &TableEnv::new(table)) {
+        for target in crate::translate::registry() {
+            translations.push(match emit::emit(target.as_ref(), &ir) {
+                Ok(emitted) => ExportTranslation {
+                    target: target.name(),
+                    code: Some(emitted.code),
+                    error: None,
+                    notes: emitted.notes,
+                },
+                Err(unsupported) => ExportTranslation {
+                    target: target.name(),
+                    code: None,
+                    error: Some(format!(
+                        "{} is not supported: {}",
+                        unsupported.what, unsupported.why
+                    )),
+                    notes: Vec::new(),
+                },
+            });
+        }
+    }
+    translations
+}
+
+/// Collect every column (and struct field, dotted) `e` references into
+/// `columns`, and every definition it references into `definitions`, each in
+/// first-appearance order, deduplicated. A bare name that resolves to a
+/// definition is not a column; a field path always starts from a column. A
+/// `COLUMNS(...)` selection expands to the table columns it matches,
+/// mirroring the S21/S22 checker — restricted to typed columns, since
+/// untyped ones are omitted from the export.
+fn collect_columns(
+    e: &Expr,
+    table: &Table,
+    referable: &HashMap<&str, &Definition>,
+    columns: &mut Vec<String>,
+    definitions: &mut Vec<String>,
+) {
     let typed_columns = || table.columns.iter().filter(|col| col.col_type.is_some());
     match &e.kind {
-        ExprKind::Column(path) => push_unique(out, path.join(".")),
+        ExprKind::Column(path) => {
+            if path.len() == 1 && referable.contains_key(path[0].as_str()) {
+                push_unique(definitions, path[0].clone());
+            } else {
+                push_unique(columns, path.join("."));
+            }
+        }
         ExprKind::Columns(selector) => match selector {
             ColumnsSelector::All => {
                 for col in typed_columns() {
-                    push_unique(out, col.name.value.clone());
+                    push_unique(columns, col.name.value.clone());
                 }
             }
             ColumnsSelector::Regex { pattern, .. } => {
                 if let Ok(re) = regex::Regex::new(pattern) {
                     for col in typed_columns() {
                         if re.is_match(&col.name.value) {
-                            push_unique(out, col.name.value.clone());
+                            push_unique(columns, col.name.value.clone());
                         }
                     }
                 }
             }
             ColumnsSelector::List(names) => {
                 for named in names {
-                    push_unique(out, named.name.clone());
+                    push_unique(columns, named.name.clone());
                 }
             }
         },
-        ExprKind::Neg(inner) | ExprKind::Not(inner) => collect_columns(inner, table, out),
+        ExprKind::Neg(inner) | ExprKind::Not(inner) => {
+            collect_columns(inner, table, referable, columns, definitions)
+        }
         ExprKind::Arith { lhs, rhs, .. }
         | ExprKind::Compare { lhs, rhs, .. }
         | ExprKind::And(lhs, rhs)
         | ExprKind::Or(lhs, rhs) => {
-            collect_columns(lhs, table, out);
-            collect_columns(rhs, table, out);
+            collect_columns(lhs, table, referable, columns, definitions);
+            collect_columns(rhs, table, referable, columns, definitions);
         }
-        ExprKind::IsNull { operand, .. } => collect_columns(operand, table, out),
+        ExprKind::IsNull { operand, .. } => {
+            collect_columns(operand, table, referable, columns, definitions)
+        }
         ExprKind::Between {
             operand, lo, hi, ..
         } => {
-            collect_columns(operand, table, out);
-            collect_columns(lo, table, out);
-            collect_columns(hi, table, out);
+            collect_columns(operand, table, referable, columns, definitions);
+            collect_columns(lo, table, referable, columns, definitions);
+            collect_columns(hi, table, referable, columns, definitions);
         }
         ExprKind::In { operand, list, .. } => {
-            collect_columns(operand, table, out);
+            collect_columns(operand, table, referable, columns, definitions);
             for item in list {
-                collect_columns(item, table, out);
+                collect_columns(item, table, referable, columns, definitions);
             }
         }
         ExprKind::Like {
@@ -843,22 +1009,22 @@ fn collect_columns(e: &Expr, table: &Table, out: &mut Vec<String>) {
         | ExprKind::SimilarTo {
             operand, pattern, ..
         } => {
-            collect_columns(operand, table, out);
-            collect_columns(pattern, table, out);
+            collect_columns(operand, table, referable, columns, definitions);
+            collect_columns(pattern, table, referable, columns, definitions);
         }
         ExprKind::Call { args, .. } => {
             for arg in args {
-                collect_columns(arg, table, out);
+                collect_columns(arg, table, referable, columns, definitions);
             }
         }
-        ExprKind::Interval { n, .. } => collect_columns(n, table, out),
+        ExprKind::Interval { n, .. } => collect_columns(n, table, referable, columns, definitions),
         ExprKind::Case { whens, els } => {
             for (when, then) in whens {
-                collect_columns(when, table, out);
-                collect_columns(then, table, out);
+                collect_columns(when, table, referable, columns, definitions);
+                collect_columns(then, table, referable, columns, definitions);
             }
             if let Some(els) = els {
-                collect_columns(els, table, out);
+                collect_columns(els, table, referable, columns, definitions);
             }
         }
         ExprKind::Number(_)

--- a/crates/data-dict/src/export.rs
+++ b/crates/data-dict/src/export.rs
@@ -26,7 +26,7 @@ use crate::model::{
     Scalar, Spanned, Table, Version,
 };
 use crate::problem::{ProblemKind, ProblemSet, Severity};
-use crate::validate_spec::{TableEnv, resolve_definitions};
+use crate::validate_spec::{DefEnv, resolve_definitions};
 use crate::{load, validate_and_lower};
 
 /// The version of the export document format itself, carried as the
@@ -599,7 +599,6 @@ fn build_table(
     profiles: &mut TableProfiles,
 ) -> ExportTable {
     let defs = resolve_definitions(table);
-    let referable = referable_definitions(table);
     ExportTable {
         name: table.name.value.clone(),
         label: table.label.as_ref().map(|s| s.value.clone()),
@@ -611,35 +610,18 @@ fn build_table(
             parquet: s.parquet.value.clone(),
         }),
         rows,
-        columns: build_columns(dict, table, &table.columns, &[], &referable, profiles),
+        columns: build_columns(dict, table, &table.columns, &[], &defs, profiles),
         constraints: table
             .constraints
             .iter()
-            .map(|a| build_assertion(a, table, &referable))
+            .map(|a| build_assertion(a, table, &defs))
             .collect(),
         definitions: table
             .definitions
             .iter()
-            .map(|d| build_definition(d, table, &defs, &referable))
+            .map(|d| build_definition(d, table, &defs))
             .collect(),
     }
-}
-
-/// The definitions a reference in one of `table`'s expressions may resolve
-/// to: the first of each non-empty name not claimed by a column (the
-/// collision is S32), with a parsed expression. Mirrors the referable set
-/// spec validation uses.
-fn referable_definitions(table: &Table) -> HashMap<&str, &Definition> {
-    let mut referable = HashMap::new();
-    for def in &table.definitions {
-        if !def.name.value.is_empty()
-            && table.column(&def.name.value).is_none()
-            && def.expr.is_some()
-        {
-            referable.entry(def.name.value.as_str()).or_insert(def);
-        }
-    }
-    referable
 }
 
 /// Build one level of the column tree. A column (or field) with no declared
@@ -649,13 +631,13 @@ fn build_columns(
     table: &Table,
     columns: &[Column],
     prefix: &[&str],
-    referable: &HashMap<&str, &Definition>,
+    defs: &HashMap<String, DefType>,
     profiles: &mut TableProfiles,
 ) -> Vec<ExportColumn> {
     columns
         .iter()
         .filter(|col| col.col_type.is_some())
-        .map(|col| build_column(dict, table, col, prefix, referable, profiles))
+        .map(|col| build_column(dict, table, col, prefix, defs, profiles))
         .collect()
 }
 
@@ -664,7 +646,7 @@ fn build_column(
     table: &Table,
     col: &Column,
     prefix: &[&str],
-    referable: &HashMap<&str, &Definition>,
+    defs: &HashMap<String, DefType>,
     profiles: &mut TableProfiles,
 ) -> ExportColumn {
     let path: Vec<&str> = prefix
@@ -756,12 +738,12 @@ fn build_column(
         fields: col
             .fields
             .as_ref()
-            .map(|fields| build_columns(dict, table, fields, &path, referable, profiles))
+            .map(|fields| build_columns(dict, table, fields, &path, defs, profiles))
             .unwrap_or_default(),
         assertions: col
             .assertions
             .iter()
-            .map(|a| build_assertion(a, table, referable))
+            .map(|a| build_assertion(a, table, defs))
             .collect(),
         profile,
     }
@@ -771,14 +753,13 @@ fn build_definition(
     def: &Definition,
     table: &Table,
     defs: &HashMap<String, DefType>,
-    referable: &HashMap<&str, &Definition>,
 ) -> ExportDefinition {
     let mut columns = Vec::new();
     let mut definitions = Vec::new();
     let mut translations = Vec::new();
     if let Some(expr) = &def.expr {
-        collect_columns(&expr.root, table, referable, &mut columns, &mut definitions);
-        translations = translate_expression(&expr.root, table, referable);
+        collect_columns(&expr.root, table, defs, &mut columns, &mut definitions);
+        translations = translate_expression(&expr.root, table, defs);
     }
     let resolved = defs.get(&def.name.value);
     let kind = match resolved {
@@ -859,14 +840,14 @@ fn representation_labels(rep: &Representation) -> BTreeMap<String, String> {
 fn build_assertion(
     assertion: &Assertion,
     table: &Table,
-    referable: &HashMap<&str, &Definition>,
+    defs: &HashMap<String, DefType>,
 ) -> ExportAssertion {
     let mut columns = Vec::new();
     let mut definitions = Vec::new();
     let mut translations = Vec::new();
     if let Some(expr) = &assertion.expr {
-        collect_columns(&expr.root, table, referable, &mut columns, &mut definitions);
-        translations = translate_expression(&expr.root, table, referable);
+        collect_columns(&expr.root, table, defs, &mut columns, &mut definitions);
+        translations = translate_expression(&expr.root, table, defs);
     }
     ExportAssertion {
         expression: assertion.text.value.clone(),
@@ -878,38 +859,19 @@ fn build_assertion(
 }
 
 /// One entry per target: the expression rendered in that target's language,
-/// or the reason the target refused. An expression that builds on another
-/// definition isn't translated — the client has the referenced definition's
-/// own translations (named by the `definitions` key) and composes them — so
-/// every target carries the reason instead. The spec pass has already
-/// checked every expression, so lowering only fails when export runs without
-/// it.
+/// or the reason the target refused. A reference to another definition
+/// renders as a bare name, as if it were a column — substituting the
+/// referenced definition's own translation (named by the `definitions` key)
+/// is the consumer's job. The spec pass has already checked every
+/// expression, so lowering only fails when export runs without it.
 fn translate_expression(
     root: &Expr,
     table: &Table,
-    referable: &HashMap<&str, &Definition>,
+    defs: &HashMap<String, DefType>,
 ) -> Vec<ExportTranslation> {
     let expr = assert_expr::AssertExpr { root: root.clone() };
-    let refs: Vec<String> = assert_expr::referenced_names(&expr)
-        .into_iter()
-        .filter(|name| referable.contains_key(name.as_str()))
-        .collect();
-    if !refs.is_empty() {
-        return crate::translate::registry()
-            .iter()
-            .map(|target| ExportTranslation {
-                target: target.name(),
-                code: None,
-                error: Some(format!(
-                    "references the definition `{}`; compose it from that definition's own translation",
-                    refs.join("`, `")
-                )),
-                notes: Vec::new(),
-            })
-            .collect();
-    }
     let mut translations = Vec::new();
-    if let Some(ir) = assert_expr::lower(&expr, &TableEnv::new(table)) {
+    if let Some(ir) = assert_expr::lower(&expr, &DefEnv::new(table, defs)) {
         for target in crate::translate::registry() {
             translations.push(match emit::emit(target.as_ref(), &ir) {
                 Ok(emitted) => ExportTranslation {
@@ -943,14 +905,14 @@ fn translate_expression(
 fn collect_columns(
     e: &Expr,
     table: &Table,
-    referable: &HashMap<&str, &Definition>,
+    defs: &HashMap<String, DefType>,
     columns: &mut Vec<String>,
     definitions: &mut Vec<String>,
 ) {
     let typed_columns = || table.columns.iter().filter(|col| col.col_type.is_some());
     match &e.kind {
         ExprKind::Column(path) => {
-            if path.len() == 1 && referable.contains_key(path[0].as_str()) {
+            if path.len() == 1 && defs.contains_key(&path[0]) {
                 push_unique(definitions, path[0].clone());
             } else {
                 push_unique(columns, path.join("."));
@@ -978,29 +940,29 @@ fn collect_columns(
             }
         },
         ExprKind::Neg(inner) | ExprKind::Not(inner) => {
-            collect_columns(inner, table, referable, columns, definitions)
+            collect_columns(inner, table, defs, columns, definitions)
         }
         ExprKind::Arith { lhs, rhs, .. }
         | ExprKind::Compare { lhs, rhs, .. }
         | ExprKind::And(lhs, rhs)
         | ExprKind::Or(lhs, rhs) => {
-            collect_columns(lhs, table, referable, columns, definitions);
-            collect_columns(rhs, table, referable, columns, definitions);
+            collect_columns(lhs, table, defs, columns, definitions);
+            collect_columns(rhs, table, defs, columns, definitions);
         }
         ExprKind::IsNull { operand, .. } => {
-            collect_columns(operand, table, referable, columns, definitions)
+            collect_columns(operand, table, defs, columns, definitions)
         }
         ExprKind::Between {
             operand, lo, hi, ..
         } => {
-            collect_columns(operand, table, referable, columns, definitions);
-            collect_columns(lo, table, referable, columns, definitions);
-            collect_columns(hi, table, referable, columns, definitions);
+            collect_columns(operand, table, defs, columns, definitions);
+            collect_columns(lo, table, defs, columns, definitions);
+            collect_columns(hi, table, defs, columns, definitions);
         }
         ExprKind::In { operand, list, .. } => {
-            collect_columns(operand, table, referable, columns, definitions);
+            collect_columns(operand, table, defs, columns, definitions);
             for item in list {
-                collect_columns(item, table, referable, columns, definitions);
+                collect_columns(item, table, defs, columns, definitions);
             }
         }
         ExprKind::Like {
@@ -1009,22 +971,22 @@ fn collect_columns(
         | ExprKind::SimilarTo {
             operand, pattern, ..
         } => {
-            collect_columns(operand, table, referable, columns, definitions);
-            collect_columns(pattern, table, referable, columns, definitions);
+            collect_columns(operand, table, defs, columns, definitions);
+            collect_columns(pattern, table, defs, columns, definitions);
         }
         ExprKind::Call { args, .. } => {
             for arg in args {
-                collect_columns(arg, table, referable, columns, definitions);
+                collect_columns(arg, table, defs, columns, definitions);
             }
         }
-        ExprKind::Interval { n, .. } => collect_columns(n, table, referable, columns, definitions),
+        ExprKind::Interval { n, .. } => collect_columns(n, table, defs, columns, definitions),
         ExprKind::Case { whens, els } => {
             for (when, then) in whens {
-                collect_columns(when, table, referable, columns, definitions);
-                collect_columns(then, table, referable, columns, definitions);
+                collect_columns(when, table, defs, columns, definitions);
+                collect_columns(then, table, defs, columns, definitions);
             }
             if let Some(els) = els {
-                collect_columns(els, table, referable, columns, definitions);
+                collect_columns(els, table, defs, columns, definitions);
             }
         }
         ExprKind::Number(_)

--- a/crates/data-dict/src/export.rs
+++ b/crates/data-dict/src/export.rs
@@ -209,6 +209,8 @@ struct ExportDefinition {
     description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     details: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    todo: Option<String>,
     expression: String,
     kind: &'static str,
     /// The expression's value type; absent when it couldn't be resolved (a
@@ -787,6 +789,7 @@ fn build_definition(
         label: def.label.clone(),
         description: prose(&def.description),
         details: prose(&def.details),
+        todo: spanned_prose(&def.todo),
         expression: def.text.value.clone(),
         kind,
         value_type,

--- a/crates/data-dict/src/export.rs
+++ b/crates/data-dict/src/export.rs
@@ -913,7 +913,7 @@ fn collect_columns(
     definitions: &mut Vec<String>,
 ) {
     let typed_columns = || table.columns.iter().filter(|col| col.col_type.is_some());
-    match &e.kind {
+    assert_expr::visit(e, |e| match &e.kind {
         ExprKind::Column(path) => {
             if path.len() == 1 && defs.contains_key(&path[0]) {
                 push_unique(definitions, path[0].clone());
@@ -942,62 +942,8 @@ fn collect_columns(
                 }
             }
         },
-        ExprKind::Neg(inner) | ExprKind::Not(inner) => {
-            collect_columns(inner, table, defs, columns, definitions)
-        }
-        ExprKind::Arith { lhs, rhs, .. }
-        | ExprKind::Compare { lhs, rhs, .. }
-        | ExprKind::And(lhs, rhs)
-        | ExprKind::Or(lhs, rhs) => {
-            collect_columns(lhs, table, defs, columns, definitions);
-            collect_columns(rhs, table, defs, columns, definitions);
-        }
-        ExprKind::IsNull { operand, .. } => {
-            collect_columns(operand, table, defs, columns, definitions)
-        }
-        ExprKind::Between {
-            operand, lo, hi, ..
-        } => {
-            collect_columns(operand, table, defs, columns, definitions);
-            collect_columns(lo, table, defs, columns, definitions);
-            collect_columns(hi, table, defs, columns, definitions);
-        }
-        ExprKind::In { operand, list, .. } => {
-            collect_columns(operand, table, defs, columns, definitions);
-            for item in list {
-                collect_columns(item, table, defs, columns, definitions);
-            }
-        }
-        ExprKind::Like {
-            operand, pattern, ..
-        }
-        | ExprKind::SimilarTo {
-            operand, pattern, ..
-        } => {
-            collect_columns(operand, table, defs, columns, definitions);
-            collect_columns(pattern, table, defs, columns, definitions);
-        }
-        ExprKind::Call { args, .. } => {
-            for arg in args {
-                collect_columns(arg, table, defs, columns, definitions);
-            }
-        }
-        ExprKind::Interval { n, .. } => collect_columns(n, table, defs, columns, definitions),
-        ExprKind::Case { whens, els } => {
-            for (when, then) in whens {
-                collect_columns(when, table, defs, columns, definitions);
-                collect_columns(then, table, defs, columns, definitions);
-            }
-            if let Some(els) = els {
-                collect_columns(els, table, defs, columns, definitions);
-            }
-        }
-        ExprKind::Number(_)
-        | ExprKind::Str(_)
-        | ExprKind::Bool(_)
-        | ExprKind::Null
-        | ExprKind::Now => {}
-    }
+        _ => {}
+    });
 }
 
 fn push_unique(out: &mut Vec<String>, name: String) {

--- a/crates/data-dict/src/export.rs
+++ b/crates/data-dict/src/export.rs
@@ -905,7 +905,7 @@ fn translate_expression(
 /// `COLUMNS(...)` selection expands to the table columns it matches,
 /// mirroring the S21/S22 checker — restricted to typed columns, since
 /// untyped ones are omitted from the export.
-fn collect_columns(
+pub(crate) fn collect_columns(
     e: &Expr,
     table: &Table,
     defs: &HashMap<String, DefType>,

--- a/crates/data-dict/src/lower.rs
+++ b/crates/data-dict/src/lower.rs
@@ -398,6 +398,11 @@ fn lower_definition(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Opt
         }
     };
 
+    let todo = entries
+        .iter()
+        .find(|e| e.key.yaml.as_str() == Some("todo"))
+        .and_then(|e| lower_todo(&e.value, e.value_span.clone()));
+
     Some(Definition {
         name: Spanned::new(name.to_string(), name_entry.value_span.clone()),
         text: Spanned::new(text.to_string(), span),
@@ -405,6 +410,7 @@ fn lower_definition(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Opt
         label: string("label"),
         description: string("description"),
         details: string("details"),
+        todo,
     })
 }
 

--- a/crates/data-dict/src/model.rs
+++ b/crates/data-dict/src/model.rs
@@ -116,6 +116,7 @@ pub struct Definition {
     pub label: Option<String>,
     pub description: Option<String>,
     pub details: Option<String>,
+    pub todo: Option<Spanned<String>>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/data-dict/src/translate.rs
+++ b/crates/data-dict/src/translate.rs
@@ -14,7 +14,7 @@ use crate::assert_expr::{self, AssertExpr, ColumnRef, Root, TypedAssertion};
 use crate::emit::{self, DuckDb, R_BASE, R_DATA_TABLE, R_TIDYVERSE, Target};
 use crate::model::{DataDict, Table};
 use crate::problem::{Problem, ProblemKind, ProblemSet};
-use crate::validate_spec::TableEnv;
+use crate::validate_spec::{DefEnv, resolve_definitions};
 
 /// Every target that can be emitted today, in a stable order.
 pub(crate) fn registry() -> Vec<Box<dyn Target>> {
@@ -197,7 +197,8 @@ fn translate_one(
     table: &Table,
     targets: &[Box<dyn Target>],
 ) -> Result<Translation, String> {
-    let env = TableEnv::new(table);
+    let defs = resolve_definitions(table);
+    let env = DefEnv::new(table, &defs);
     let expr = AssertExpr::parse(source)
         .map_err(|e| format!("expression does not parse: {}", e.message))?;
     // An ad-hoc expression need not be a rule, so it need not be boolean.
@@ -224,7 +225,8 @@ fn translate_assertions(
         .iter()
         .filter(|t| only.is_none_or(|name| t.name.value == name))
     {
-        let env = TableEnv::new(table);
+        let defs = resolve_definitions(table);
+        let env = DefEnv::new(table, &defs);
         let assertions = table
             .constraints
             .iter()

--- a/crates/data-dict/src/translate.rs
+++ b/crates/data-dict/src/translate.rs
@@ -6,11 +6,16 @@
 //!
 //! Output is JSON because this is mostly read by other programs; the `columns`
 //! list is what makes it composable, since a caller can tell which columns to
-//! load without parsing the code it was given.
+//! load without parsing the code it was given. A reference to a definition is
+//! not a loadable column, so those are listed separately under `definitions`
+//! — substituting the definition's own translation is the caller's job, as
+//! `site/export.md` specifies.
 
+use std::collections::HashMap;
 use std::path::Path;
 
-use crate::assert_expr::{self, AssertExpr, ColumnRef, Root, TypedAssertion};
+use crate::assert_expr::{self, AssertExpr, DefType, Root, TypedAssertion};
+use crate::export::collect_columns;
 use crate::emit::{self, DuckDb, R_BASE, R_DATA_TABLE, R_TIDYVERSE, Target};
 use crate::model::{DataDict, Table};
 use crate::problem::{Problem, ProblemKind, ProblemSet};
@@ -85,15 +90,12 @@ pub struct Translation {
     /// The expression's own type; `boolean` for an assertion.
     #[serde(rename = "type")]
     pub ty: &'static str,
-    /// The columns the expression reads, qualified by table.
-    pub columns: Vec<ColumnUse>,
+    /// The columns the expression reads, in first-appearance order.
+    pub columns: Vec<String>,
+    /// The definitions of the same table it references.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub definitions: Vec<String>,
     pub translations: Vec<TargetOutput>,
-}
-
-#[derive(Debug, serde::Serialize)]
-pub struct ColumnUse {
-    pub table: String,
-    pub column: String,
 }
 
 /// One target's answer: either code, or the reason it refused.
@@ -211,7 +213,7 @@ fn translate_one(
     }
     let ir = assert_expr::lower(&expr, &env)
         .ok_or("expression could not be resolved against this table")?;
-    Ok(render(source, &table.name.value, &ir, targets))
+    Ok(render(source, &expr, table, &defs, &ir, targets))
 }
 
 fn translate_assertions(
@@ -240,7 +242,9 @@ fn translate_assertions(
             };
             out.push(render(
                 &assertion.text.value,
-                &table.name.value,
+                expr,
+                table,
+                &defs,
                 &ir,
                 targets,
             ));
@@ -251,22 +255,21 @@ fn translate_assertions(
 
 fn render(
     source: &str,
-    table: &str,
+    expr: &AssertExpr,
+    table: &Table,
+    defs: &HashMap<String, DefType>,
     ir: &TypedAssertion,
     targets: &[Box<dyn Target>],
 ) -> Translation {
+    let mut columns = Vec::new();
+    let mut definitions = Vec::new();
+    collect_columns(&expr.root, table, defs, &mut columns, &mut definitions);
     Translation {
         expr: source.to_string(),
-        table: table.to_string(),
+        table: table.name.value.clone(),
         ty: ir.root.ty.name(),
-        columns: ir
-            .columns()
-            .iter()
-            .map(|c: &ColumnRef| ColumnUse {
-                table: table.to_string(),
-                column: c.path.join("."),
-            })
-            .collect(),
+        columns,
+        definitions,
         // A target that refuses says so and the rest still translate.
         translations: targets
             .iter()

--- a/crates/data-dict/src/validate_data.rs
+++ b/crates/data-dict/src/validate_data.rs
@@ -248,6 +248,7 @@ fn assertion_issues(
     out: &mut ProblemSet,
 ) -> Result<(), data_dict_parquet::ParquetError> {
     let env = crate::validate_spec::TableEnv::new(table);
+    let defs = crate::validate_spec::definition_exprs(table);
     let column_assertions = table
         .columns
         .iter()
@@ -265,7 +266,10 @@ fn assertion_issues(
         let Some(expr) = &assertion.expr else {
             continue;
         };
-        let Some(ir) = crate::assert_expr::lower(expr, &env) else {
+        // A reference to a definition must become the definition's expression
+        // to evaluate: the data has no such column.
+        let expr = crate::assert_expr::substitute_definitions(expr, &defs);
+        let Some(ir) = crate::assert_expr::lower(&expr, &env) else {
             continue;
         };
 

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -429,42 +429,83 @@ fn run_assertion_check(
         out,
     );
 
-    // The at-most-one `COLUMNS(...)` rule binds the expression as it
-    // evaluates, with definition references substituted in: an assertion and
-    // a filter it references may each use one, which combines to two. Report
-    // each reference that brings a selection in over the budget of one. (More
-    // than one in the assertion's own text was already reported above.)
+    check_expanded_selections(table, expr, None, &assertion.text, enclosing, out);
+}
+
+/// The `COLUMNS(...)` rules bind the expression as it evaluates, with
+/// definition references substituted in: a selection travels to whatever
+/// references the definition holding it. Report each reference that brings a
+/// selection in over the budget of one, and — for a definition (`ty` is
+/// `Some`), where a selection is meaningful only in a boolean filter — a
+/// reference that brings one into a non-boolean expression. Selections in the
+/// expression's own text were already checked by `analyze`.
+fn check_expanded_selections(
+    table: &Table,
+    expr: &assert_expr::AssertExpr,
+    ty: Option<assert_expr::Ty>,
+    text: &Spanned<String>,
+    enclosing: &[&Spanned<String>],
+    out: &mut ProblemSet,
+) {
     let own = assert_expr::columns_selection_count(expr);
-    if own <= 1 {
-        let defs = definition_exprs(table);
-        let with_selection: std::collections::HashSet<&str> = defs
-            .iter()
-            .filter(|(_, e)| assert_expr::columns_selection_count(e) > 0)
-            .map(|(name, _)| name.as_str())
-            .collect();
-        let mut refs: Vec<(usize, usize)> = Vec::new();
-        assert_expr::visit(&expr.root, |e| {
-            if let assert_expr::ExprKind::Column(path) = &e.kind
-                && path.len() == 1
-                && with_selection.contains(path[0].as_str())
-            {
-                refs.push((e.start, e.end));
-            }
-        });
-        // The first selection is the allowed one: the assertion's own if it
-        // has one, else the first reference's.
-        for &(start, end) in refs.iter().skip(1 - own) {
-            let span = subspan(&assertion.text.span, start, end)
-                .unwrap_or_else(|| assertion.text.span.clone());
+    if own > 1 {
+        return;
+    }
+    let defs = definition_exprs(table);
+    let with_selection: std::collections::HashSet<&str> = defs
+        .iter()
+        .filter(|(_, e)| assert_expr::columns_selection_count(e) > 0)
+        .map(|(name, _)| name.as_str())
+        .collect();
+    let mut refs: Vec<(String, usize, usize)> = Vec::new();
+    assert_expr::visit(&expr.root, |e| {
+        if let assert_expr::ExprKind::Column(path) = &e.kind
+            && path.len() == 1
+            && with_selection.contains(path[0].as_str())
+        {
+            refs.push((path[0].clone(), e.start, e.end));
+        }
+    });
+    if refs.is_empty() {
+        return;
+    }
+    let report =
+        |out: &mut ProblemSet, start: usize, end: usize, expected: &str, message: String| {
+            let span = subspan(&text.span, start, end).unwrap_or_else(|| text.span.clone());
             let mut spans: Vec<SourceInfo> = enclosing.iter().map(|s| s.span.clone()).collect();
             spans.push(span);
-            out.push_spec_error(
-                "S21",
-                "An expression may use at most one `COLUMNS(...)`.",
-                "recursively includes `COLUMNS(...)`",
-                spans,
-            );
-        }
+            out.push_spec_error("S21", expected, message, spans);
+        };
+
+    if let Some(ty) = ty
+        && own == 0
+        && !matches!(
+            ty,
+            assert_expr::Ty::Bool | assert_expr::Ty::Any | assert_expr::Ty::Unknown
+        )
+    {
+        let (name, start, end) = &refs[0];
+        report(
+            out,
+            *start,
+            *end,
+            "An expression using `COLUMNS(...)` must be a boolean filter.",
+            format!(
+                "`{name}` recursively includes `COLUMNS(...)` and the expression is not a boolean"
+            ),
+        );
+    }
+
+    // The first selection is the allowed one: the expression's own if it has
+    // one, else the first reference's.
+    for (_, start, end) in refs.iter().skip(1 - own) {
+        report(
+            out,
+            *start,
+            *end,
+            "An expression may use at most one `COLUMNS(...)`.",
+            "recursively includes `COLUMNS(...)`".to_string(),
+        );
     }
 }
 
@@ -653,6 +694,14 @@ fn check_definition_exprs(table: &Table, out: &mut ProblemSet) -> HashMap<String
                     &def.text,
                     &[&table.name, &def.name],
                     &DEFINITION_WORDING,
+                    out,
+                );
+                check_expanded_selections(
+                    table,
+                    expr,
+                    Some(ty),
+                    &def.text,
+                    &[&table.name, &def.name],
                     out,
                 );
                 let is_referable = referable

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -471,13 +471,13 @@ fn report_findings(
 
 /// A [`TableEnv`] plus the definitions resolved so far, so a definition's
 /// expression can reference other definitions.
-struct DefEnv<'a> {
+pub(crate) struct DefEnv<'a> {
     inner: TableEnv<'a>,
     defs: &'a HashMap<String, DefType>,
 }
 
 impl<'a> DefEnv<'a> {
-    fn new(table: &'a Table, defs: &'a HashMap<String, DefType>) -> DefEnv<'a> {
+    pub(crate) fn new(table: &'a Table, defs: &'a HashMap<String, DefType>) -> DefEnv<'a> {
         DefEnv {
             inner: TableEnv::new(table),
             defs,

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -476,6 +476,15 @@ struct DefEnv<'a> {
     defs: &'a HashMap<String, DefType>,
 }
 
+impl<'a> DefEnv<'a> {
+    fn new(table: &'a Table, defs: &'a HashMap<String, DefType>) -> DefEnv<'a> {
+        DefEnv {
+            inner: TableEnv::new(table),
+            defs,
+        }
+    }
+}
+
 impl CheckEnv for DefEnv<'_> {
     fn column(&self, name: &str) -> Option<ColumnKind> {
         self.inner.column(name)
@@ -657,6 +666,66 @@ fn check_definition_exprs(table: &Table, out: &mut ProblemSet) -> HashMap<String
                 // Unreachable (a finite graph with no resolvable node contains
                 // a cycle), but don't loop forever if the reasoning is off.
                 break;
+            }
+        }
+    }
+    resolved
+}
+
+/// Resolve every referable definition's type and shape in dependency order,
+/// discarding findings. For export, which runs only after spec validation
+/// has passed, so there is nothing to report; a definition that can't be
+/// resolved (a reference cycle, already reported as S33) maps to the
+/// permissive `Ty::Any`, as it does during validation.
+pub(crate) fn resolve_definitions(table: &Table) -> HashMap<String, DefType> {
+    use crate::assert_expr::FindingSeverity;
+
+    let mut referable: HashMap<&str, &Definition> = HashMap::new();
+    for def in &table.definitions {
+        if !def.name.value.is_empty()
+            && table.column(&def.name.value).is_none()
+            && def.expr.is_some()
+        {
+            referable.entry(def.name.value.as_str()).or_insert(def);
+        }
+    }
+
+    let mut resolved: HashMap<String, DefType> = HashMap::new();
+    let mut pending: Vec<&Definition> = referable.values().copied().collect();
+    while !pending.is_empty() {
+        let before = pending.len();
+        let mut i = 0;
+        while i < pending.len() {
+            let def = pending[i];
+            let deps = definition_refs(def, &referable);
+            if deps.iter().all(|d| resolved.contains_key(*d)) {
+                let env = DefEnv::new(table, &resolved);
+                let expr = def.expr.as_ref().unwrap();
+                let (ty, shape, findings) = assert_expr::analyze(expr, &env, Root::Definition);
+                let failed = findings
+                    .iter()
+                    .any(|f| f.severity == FindingSeverity::Error);
+                resolved.insert(
+                    def.name.value.clone(),
+                    DefType {
+                        ty: if failed { assert_expr::Ty::Any } else { ty },
+                        shape,
+                    },
+                );
+                pending.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        if pending.len() == before {
+            for def in pending.drain(..) {
+                resolved.insert(
+                    def.name.value.clone(),
+                    DefType {
+                        ty: assert_expr::Ty::Any,
+                        shape: assert_expr::Shape::Row,
+                    },
+                );
             }
         }
     }

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -566,19 +566,28 @@ fn check_definition_exprs(table: &Table, out: &mut ProblemSet) -> HashMap<String
 
     // The definitions a reference may resolve to: the first of each non-empty
     // name, excluding names a column claims (references there resolve to the
-    // column; the collision is S33) and expressions that didn't parse (S19).
+    // column; the collision is S33).
     let mut referable: HashMap<&str, &Definition> = HashMap::new();
     for def in &table.definitions {
-        if !def.name.value.is_empty()
-            && table.column(&def.name.value).is_none()
-            && def.expr.is_some()
-        {
+        if !def.name.value.is_empty() && table.column(&def.name.value).is_none() {
             referable.entry(def.name.value.as_str()).or_insert(def);
         }
     }
     let def_refs = |def: &Definition| definition_refs(def, &referable);
 
+    // A definition whose expression didn't parse (S19, reported at lowering)
+    // resolves to the permissive `Ty::Any`, so its referencers don't cascade
+    // its error — the same treatment a failed check gets below.
     let mut resolved: HashMap<String, DefType> = HashMap::new();
+    for def in referable.values().filter(|d| d.expr.is_none()) {
+        resolved.insert(
+            def.name.value.clone(),
+            DefType {
+                ty: assert_expr::Ty::Any,
+                shape: assert_expr::Shape::Row,
+            },
+        );
+    }
     let mut pending: Vec<&Definition> = table
         .definitions
         .iter()
@@ -682,16 +691,28 @@ pub(crate) fn resolve_definitions(table: &Table) -> HashMap<String, DefType> {
 
     let mut referable: HashMap<&str, &Definition> = HashMap::new();
     for def in &table.definitions {
-        if !def.name.value.is_empty()
-            && table.column(&def.name.value).is_none()
-            && def.expr.is_some()
-        {
+        if !def.name.value.is_empty() && table.column(&def.name.value).is_none() {
             referable.entry(def.name.value.as_str()).or_insert(def);
         }
     }
 
+    // A definition whose expression didn't parse resolves to `Ty::Any`, as in
+    // `check_definition_exprs`.
     let mut resolved: HashMap<String, DefType> = HashMap::new();
-    let mut pending: Vec<&Definition> = referable.values().copied().collect();
+    let mut pending: Vec<&Definition> = Vec::new();
+    for def in referable.values() {
+        if def.expr.is_some() {
+            pending.push(def);
+        } else {
+            resolved.insert(
+                def.name.value.clone(),
+                DefType {
+                    ty: assert_expr::Ty::Any,
+                    shape: assert_expr::Shape::Row,
+                },
+            );
+        }
+    }
     while !pending.is_empty() {
         let before = pending.len();
         let mut i = 0;
@@ -727,6 +748,49 @@ pub(crate) fn resolve_definitions(table: &Table) -> HashMap<String, DefType> {
                     },
                 );
             }
+        }
+    }
+    resolved
+}
+
+/// The table's referable definitions as name → expression, each with its own
+/// definition references already substituted, resolved in dependency order.
+/// For evaluation against data, where a definition reference must become the
+/// definition's expression. Runs only after spec validation has passed, so
+/// every expression parses and no cycle survives; anything unresolvable is
+/// omitted.
+pub(crate) fn definition_exprs(table: &Table) -> HashMap<String, assert_expr::AssertExpr> {
+    let mut referable: HashMap<&str, &Definition> = HashMap::new();
+    for def in &table.definitions {
+        if !def.name.value.is_empty()
+            && table.column(&def.name.value).is_none()
+            && def.expr.is_some()
+        {
+            referable.entry(def.name.value.as_str()).or_insert(def);
+        }
+    }
+
+    let mut resolved: HashMap<String, assert_expr::AssertExpr> = HashMap::new();
+    let mut pending: Vec<&Definition> = referable.values().copied().collect();
+    while !pending.is_empty() {
+        let before = pending.len();
+        let mut i = 0;
+        while i < pending.len() {
+            let def = pending[i];
+            let deps = definition_refs(def, &referable);
+            if deps.iter().all(|d| resolved.contains_key(*d)) {
+                let expr = def.expr.as_ref().unwrap();
+                resolved.insert(
+                    def.name.value.clone(),
+                    assert_expr::substitute_definitions(expr, &resolved),
+                );
+                pending.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        if pending.len() == before {
+            break;
         }
     }
     resolved
@@ -1964,12 +2028,16 @@ fn fmt_backtick_list(keys: &[&str]) -> String {
 // --- S31 --------------------------------------------------------------
 
 /// Warn for every `todo` left anywhere in the dictionary: the dataset, each
-/// table, column, and struct field (recursively), and each relationship.
+/// table, column, struct field (recursively), and definition, and each
+/// relationship.
 fn validate_s31_todos(dict: &DataDict, out: &mut ProblemSet) {
     report_todo(&dict.todo, &[], out);
     for table in &dict.tables {
         report_todo(&table.todo, &[&table.name.span], out);
         report_column_todos(table, &table.columns, out);
+        for def in &table.definitions {
+            report_todo(&def.todo, &[&table.name.span, &def.name.span], out);
+        }
     }
     for rel in &dict.relationships {
         report_todo(&rel.todo, &[&rel.join_text.span], out);

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -371,7 +371,7 @@ fn validate_column_assertions(
         defs,
     };
     for assertion in &col.assertions {
-        run_assertion_check(&env, assertion, &[&table.name, &col.name], out);
+        run_assertion_check(&env, table, assertion, &[&table.name, &col.name], out);
     }
 }
 
@@ -381,7 +381,7 @@ fn validate_table_assertions(table: &Table, defs: &HashMap<String, DefType>, out
         defs,
     };
     for assertion in &table.constraints {
-        run_assertion_check(&env, assertion, &[&table.name], out);
+        run_assertion_check(&env, table, assertion, &[&table.name], out);
     }
 }
 
@@ -414,6 +414,7 @@ const DEFINITION_WORDING: ExprWording = ExprWording {
 /// for a column assertion) shown as context before the offending token.
 fn run_assertion_check(
     env: &dyn CheckEnv,
+    table: &Table,
     assertion: &Assertion,
     enclosing: &[&Spanned<String>],
     out: &mut ProblemSet,
@@ -427,6 +428,44 @@ fn run_assertion_check(
         &ASSERTION_WORDING,
         out,
     );
+
+    // The at-most-one `COLUMNS(...)` rule binds the expression as it
+    // evaluates, with definition references substituted in: an assertion and
+    // a filter it references may each use one, which combines to two. Report
+    // each reference that brings a selection in over the budget of one. (More
+    // than one in the assertion's own text was already reported above.)
+    let own = assert_expr::columns_selection_count(expr);
+    if own <= 1 {
+        let defs = definition_exprs(table);
+        let with_selection: std::collections::HashSet<&str> = defs
+            .iter()
+            .filter(|(_, e)| assert_expr::columns_selection_count(e) > 0)
+            .map(|(name, _)| name.as_str())
+            .collect();
+        let mut refs: Vec<(usize, usize)> = Vec::new();
+        assert_expr::visit(&expr.root, |e| {
+            if let assert_expr::ExprKind::Column(path) = &e.kind
+                && path.len() == 1
+                && with_selection.contains(path[0].as_str())
+            {
+                refs.push((e.start, e.end));
+            }
+        });
+        // The first selection is the allowed one: the assertion's own if it
+        // has one, else the first reference's.
+        for &(start, end) in refs.iter().skip(1 - own) {
+            let span = subspan(&assertion.text.span, start, end)
+                .unwrap_or_else(|| assertion.text.span.clone());
+            let mut spans: Vec<SourceInfo> = enclosing.iter().map(|s| s.span.clone()).collect();
+            spans.push(span);
+            out.push_spec_error(
+                "S21",
+                "An expression may use at most one `COLUMNS(...)`.",
+                "recursively includes `COLUMNS(...)`",
+                spans,
+            );
+        }
+    }
 }
 
 /// Turn one expression's findings into located problems. `enclosing` are the

--- a/crates/data-dict/tests/export.rs
+++ b/crates/data-dict/tests/export.rs
@@ -765,30 +765,25 @@ fn definitions_export_resolved() {
     );
     assert_eq!(assertion["columns"], serde_json::json!([]));
 
-    // Definitions carry translations — but one that builds on another
-    // definition is left for the client to compose, with every target
-    // carrying the reason.
+    // Definitions carry translations. A reference to another definition
+    // renders as a bare name, as if it were a column — the client
+    // substitutes the referenced definition's own translation.
     let filter_sql = &defs[1]["translations"][0];
     assert_eq!(filter_sql["target"], "SQL(duckdb)");
     assert!(filter_sql["code"].as_str().unwrap().contains("tile_size"));
 
-    let metric_translation = &defs[2]["translations"][0];
-    assert!(metric_translation.get("code").is_none());
+    let metric_sql = defs[2]["translations"][0]["code"].as_str().unwrap();
     assert!(
-        metric_translation["error"]
-            .as_str()
-            .unwrap()
-            .contains("is_enterprise")
+        metric_sql.contains("\"is_enterprise\""),
+        "reference rendered as a name: {metric_sql}"
     );
+    assert!(metric_sql.contains("order_total"));
 
-    // So is an assertion that references a definition.
-    let assertion_translation = &assertion["translations"][0];
-    assert!(assertion_translation.get("code").is_none());
+    // So does an assertion that references a definition.
+    let assertion_sql = assertion["translations"][0]["code"].as_str().unwrap();
     assert!(
-        assertion_translation["error"]
-            .as_str()
-            .unwrap()
-            .contains("is_enterprise")
+        assertion_sql.contains("\"is_enterprise\""),
+        "reference rendered as a name: {assertion_sql}"
     );
 }
 

--- a/crates/data-dict/tests/export.rs
+++ b/crates/data-dict/tests/export.rs
@@ -692,3 +692,136 @@ fn export_data_skips_columns_absent_from_the_data() {
     assert_eq!(columns[0]["profile"]["distinct"]["count"], 3);
     assert!(columns[1]["profile"].is_null(), "no data, no profile");
 }
+
+/// Definitions export with their kind, value type, and references resolved:
+/// a filter, a metric, a derived value, one definition building on another,
+/// and an assertion that references a definition.
+#[test]
+fn definitions_export_resolved() {
+    let json = export_json(indoc! {r#"
+        $version: "0.1.0"
+        tables:
+          - name: orders
+            columns:
+              - name: status_cd
+                type: number(id)
+                examples: [90]
+              - name: order_total
+                type: number(quantity)
+                units: usd
+                range: [0, .inf]
+              - name: tile_size
+                type: string
+                examples: ["Enterprise-1"]
+            constraints:
+              - assert: is_enterprise
+            definitions:
+              - name: net_revenue
+                description: Realized revenue excluding returned orders.
+                expr: SUM(CASE WHEN status_cd = 90 THEN 0 ELSE order_total END)
+              - name: is_enterprise
+                label: Enterprise segment
+                expr: tile_size IN ('Mid-Market-3', 'Enterprise-1')
+              - name: enterprise_revenue
+                expr: SUM(CASE WHEN is_enterprise THEN order_total ELSE 0 END)
+              - name: list_price
+                expr: order_total * 1.2
+    "#});
+    let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let defs = &json["tables"][0]["definitions"];
+
+    assert_eq!(defs[0]["name"], "net_revenue");
+    assert_eq!(defs[0]["kind"], "metric");
+    assert_eq!(defs[0]["type"], "number");
+    assert_eq!(
+        defs[0]["description"],
+        "<p>Realized revenue excluding returned orders.</p>"
+    );
+    assert_eq!(
+        defs[0]["columns"],
+        serde_json::json!(["status_cd", "order_total"])
+    );
+    assert!(defs[0].get("definitions").is_none());
+
+    assert_eq!(defs[1]["kind"], "filter");
+    assert_eq!(defs[1]["type"], "boolean");
+    assert_eq!(defs[1]["label"], "Enterprise segment");
+    assert_eq!(defs[1]["columns"], serde_json::json!(["tile_size"]));
+
+    // A definition building on another names it under `definitions`; the
+    // columns that definition reads stay on its own entry.
+    assert_eq!(defs[2]["kind"], "metric");
+    assert_eq!(defs[2]["definitions"], serde_json::json!(["is_enterprise"]));
+    assert_eq!(defs[2]["columns"], serde_json::json!(["order_total"]));
+
+    assert_eq!(defs[3]["kind"], "derived");
+    assert_eq!(defs[3]["type"], "number");
+
+    // An assertion referencing a definition lists it separately from columns.
+    let assertion = &json["tables"][0]["constraints"][0];
+    assert_eq!(
+        assertion["definitions"],
+        serde_json::json!(["is_enterprise"])
+    );
+    assert_eq!(assertion["columns"], serde_json::json!([]));
+
+    // Definitions carry translations — but one that builds on another
+    // definition is left for the client to compose, with every target
+    // carrying the reason.
+    let filter_sql = &defs[1]["translations"][0];
+    assert_eq!(filter_sql["target"], "SQL(duckdb)");
+    assert!(filter_sql["code"].as_str().unwrap().contains("tile_size"));
+
+    let metric_translation = &defs[2]["translations"][0];
+    assert!(metric_translation.get("code").is_none());
+    assert!(
+        metric_translation["error"]
+            .as_str()
+            .unwrap()
+            .contains("is_enterprise")
+    );
+
+    // So is an assertion that references a definition.
+    let assertion_translation = &assertion["translations"][0];
+    assert!(assertion_translation.get("code").is_none());
+    assert!(
+        assertion_translation["error"]
+            .as_str()
+            .unwrap()
+            .contains("is_enterprise")
+    );
+}
+
+/// The full export of a dictionary with definitions, so the shape is reviewable.
+#[test]
+fn definitions_export_snapshot() {
+    insta::assert_snapshot!(export_json(indoc! {r#"
+        $version: "0.1.0"
+        tables:
+          - name: orders
+            columns:
+              - name: status_cd
+                type: number(id)
+                examples: [90]
+              - name: order_total
+                type: number(quantity)
+                units: usd
+                range: [0, .inf]
+              - name: tile_size
+                type: string
+                examples: ["Enterprise-1"]
+            constraints:
+              - assert: is_enterprise
+            definitions:
+              - name: net_revenue
+                description: Realized revenue excluding returned orders.
+                expr: SUM(CASE WHEN status_cd = 90 THEN 0 ELSE order_total END)
+              - name: is_enterprise
+                label: Enterprise segment
+                expr: tile_size IN ('Mid-Market-3', 'Enterprise-1')
+              - name: enterprise_revenue
+                expr: SUM(CASE WHEN is_enterprise THEN order_total ELSE 0 END)
+              - name: list_price
+                expr: order_total * 1.2
+    "#}));
+}

--- a/crates/data-dict/tests/snapshots/export__definitions_export_snapshot.snap
+++ b/crates/data-dict/tests/snapshots/export__definitions_export_snapshot.snap
@@ -1,0 +1,150 @@
+---
+source: crates/data-dict/tests/export.rs
+expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tables:\n          - name: orders\n            columns:\n              - name: status_cd\n                type: number(id)\n                examples: [90]\n              - name: order_total\n                type: number(quantity)\n                units: usd\n                range: [0, .inf]\n              - name: tile_size\n                type: string\n                examples: [\"Enterprise-1\"]\n            constraints:\n              - assert: is_enterprise\n            definitions:\n              - name: net_revenue\n                description: Realized revenue excluding returned orders.\n                expr: SUM(CASE WHEN status_cd = 90 THEN 0 ELSE order_total END)\n              - name: is_enterprise\n                label: Enterprise segment\n                expr: tile_size IN ('Mid-Market-3', 'Enterprise-1')\n              - name: enterprise_revenue\n                expr: SUM(CASE WHEN is_enterprise THEN order_total ELSE 0 END)\n              - name: list_price\n                expr: order_total * 1.2\n    \"#})"
+---
+{
+  "$version": "0.1.0",
+  "tables": [
+    {
+      "name": "orders",
+      "columns": [
+        {
+          "name": "status_cd",
+          "type": "number(id)",
+          "examples": [
+            90
+          ]
+        },
+        {
+          "name": "order_total",
+          "type": "number(quantity)",
+          "units": "usd",
+          "range": {
+            "min": 0,
+            "max": null
+          }
+        },
+        {
+          "name": "tile_size",
+          "type": "string",
+          "examples": [
+            "Enterprise-1"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "expression": "is_enterprise",
+          "columns": [],
+          "definitions": [
+            "is_enterprise"
+          ],
+          "translations": [
+            {
+              "target": "SQL(duckdb)",
+              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+            },
+            {
+              "target": "R(tidyverse)",
+              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+            }
+          ]
+        }
+      ],
+      "definitions": [
+        {
+          "name": "net_revenue",
+          "description": "<p>Realized revenue excluding returned orders.</p>",
+          "expression": "SUM(CASE WHEN status_cd = 90 THEN 0 ELSE order_total END)",
+          "kind": "metric",
+          "type": "number",
+          "columns": [
+            "status_cd",
+            "order_total"
+          ],
+          "translations": [
+            {
+              "target": "SQL(duckdb)",
+              "code": "sum(CASE WHEN \"status_cd\" = 90 THEN 0 ELSE \"order_total\" END)",
+              "notes": [
+                "DuckDB compares a NaN as equal to itself and greater than every number, where data-dict answers false; a row holding one passes here and is reported there.",
+                "DuckDB sums integers at 128 bits, so a total data-dict reports as an overflow (D09) may succeed."
+              ]
+            },
+            {
+              "target": "R(tidyverse)",
+              "code": "sum(case_when(status_cd == 90L ~ 0L, .default = order_total), na.rm = TRUE)",
+              "notes": [
+                "R folds an empty or all-null column to the identity (0, FALSE, TRUE, Inf) where data-dict returns null — and data-dict gives an infinity only for a column that really holds one — so an aggregate assertion differs on such a column.",
+                "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
+                "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there.",
+                "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
+              ]
+            }
+          ]
+        },
+        {
+          "name": "is_enterprise",
+          "label": "Enterprise segment",
+          "expression": "tile_size IN ('Mid-Market-3', 'Enterprise-1')",
+          "kind": "filter",
+          "type": "boolean",
+          "columns": [
+            "tile_size"
+          ],
+          "translations": [
+            {
+              "target": "SQL(duckdb)",
+              "code": "\"tile_size\" IN ('Mid-Market-3', 'Enterprise-1')"
+            },
+            {
+              "target": "R(tidyverse)",
+              "code": "is.na(tile_size) | (tile_size %in% c(\"Mid-Market-3\", \"Enterprise-1\"))"
+            }
+          ]
+        },
+        {
+          "name": "enterprise_revenue",
+          "expression": "SUM(CASE WHEN is_enterprise THEN order_total ELSE 0 END)",
+          "kind": "metric",
+          "type": "number",
+          "columns": [
+            "order_total"
+          ],
+          "definitions": [
+            "is_enterprise"
+          ],
+          "translations": [
+            {
+              "target": "SQL(duckdb)",
+              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+            },
+            {
+              "target": "R(tidyverse)",
+              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+            }
+          ]
+        },
+        {
+          "name": "list_price",
+          "expression": "order_total * 1.2",
+          "kind": "derived",
+          "type": "number",
+          "columns": [
+            "order_total"
+          ],
+          "translations": [
+            {
+              "target": "SQL(duckdb)",
+              "code": "\"order_total\" * 1.2"
+            },
+            {
+              "target": "R(tidyverse)",
+              "code": "order_total * 1.2"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/crates/data-dict/tests/snapshots/export__definitions_export_snapshot.snap
+++ b/crates/data-dict/tests/snapshots/export__definitions_export_snapshot.snap
@@ -47,6 +47,14 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
             {
               "target": "R(tidyverse)",
               "code": "is_enterprise"
+            },
+            {
+              "target": "R(base)",
+              "code": "is_enterprise"
+            },
+            {
+              "target": "R(data.table)",
+              "code": "is_enterprise"
             }
           ]
         }
@@ -80,6 +88,26 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
                 "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there.",
                 "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
               ]
+            },
+            {
+              "target": "R(base)",
+              "code": "sum(ifelse(status_cd == 90L, 0L, order_total), na.rm = TRUE)",
+              "notes": [
+                "R folds an empty or all-null column to the identity (0, FALSE, TRUE, Inf) where data-dict returns null — and data-dict gives an infinity only for a column that really holds one — so an aggregate assertion differs on such a column.",
+                "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
+                "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there.",
+                "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
+              ]
+            },
+            {
+              "target": "R(data.table)",
+              "code": "sum(fcase(status_cd == 90L, 0L, default = order_total), na.rm = TRUE)",
+              "notes": [
+                "R folds an empty or all-null column to the identity (0, FALSE, TRUE, Inf) where data-dict returns null — and data-dict gives an infinity only for a column that really holds one — so an aggregate assertion differs on such a column.",
+                "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
+                "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there.",
+                "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
+              ]
             }
           ]
         },
@@ -99,6 +127,14 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
             },
             {
               "target": "R(tidyverse)",
+              "code": "is.na(tile_size) | (tile_size %in% c(\"Mid-Market-3\", \"Enterprise-1\"))"
+            },
+            {
+              "target": "R(base)",
+              "code": "is.na(tile_size) | (tile_size %in% c(\"Mid-Market-3\", \"Enterprise-1\"))"
+            },
+            {
+              "target": "R(data.table)",
               "code": "is.na(tile_size) | (tile_size %in% c(\"Mid-Market-3\", \"Enterprise-1\"))"
             }
           ]
@@ -130,6 +166,24 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
                 "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
                 "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
               ]
+            },
+            {
+              "target": "R(base)",
+              "code": "sum(ifelse(is_enterprise, order_total, 0L), na.rm = TRUE)",
+              "notes": [
+                "R folds an empty or all-null column to the identity (0, FALSE, TRUE, Inf) where data-dict returns null — and data-dict gives an infinity only for a column that really holds one — so an aggregate assertion differs on such a column.",
+                "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
+                "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
+              ]
+            },
+            {
+              "target": "R(data.table)",
+              "code": "sum(fcase(is_enterprise, order_total, default = 0L), na.rm = TRUE)",
+              "notes": [
+                "R folds an empty or all-null column to the identity (0, FALSE, TRUE, Inf) where data-dict returns null — and data-dict gives an infinity only for a column that really holds one — so an aggregate assertion differs on such a column.",
+                "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
+                "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
+              ]
             }
           ]
         },
@@ -148,6 +202,14 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
             },
             {
               "target": "R(tidyverse)",
+              "code": "order_total * 1.2"
+            },
+            {
+              "target": "R(base)",
+              "code": "order_total * 1.2"
+            },
+            {
+              "target": "R(data.table)",
               "code": "order_total * 1.2"
             }
           ]

--- a/crates/data-dict/tests/snapshots/export__definitions_export_snapshot.snap
+++ b/crates/data-dict/tests/snapshots/export__definitions_export_snapshot.snap
@@ -42,11 +42,11 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
           "translations": [
             {
               "target": "SQL(duckdb)",
-              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+              "code": "\"is_enterprise\""
             },
             {
               "target": "R(tidyverse)",
-              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+              "code": "is_enterprise"
             }
           ]
         }
@@ -117,11 +117,19 @@ expression: "export_json(indoc!\n{r#\"\n        $version: \"0.1.0\"\n        tab
           "translations": [
             {
               "target": "SQL(duckdb)",
-              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+              "code": "sum(CASE WHEN \"is_enterprise\" THEN \"order_total\" ELSE 0 END)",
+              "notes": [
+                "DuckDB sums integers at 128 bits, so a total data-dict reports as an overflow (D09) may succeed."
+              ]
             },
             {
               "target": "R(tidyverse)",
-              "error": "references the definition `is_enterprise`; compose it from that definition's own translation"
+              "code": "sum(case_when(is_enterprise ~ order_total, .default = 0L), na.rm = TRUE)",
+              "notes": [
+                "R folds an empty or all-null column to the identity (0, FALSE, TRUE, Inf) where data-dict returns null — and data-dict gives an infinity only for a column that really holds one — so an aggregate assertion differs on such a column.",
+                "R has no 64-bit integers, so arithmetic data-dict reports as an overflow (D09) yields a double here.",
+                "`na.rm = TRUE` drops a NaN along with the nulls, where data-dict folds it in — so an aggregate over a column holding one differs."
+              ]
             }
           ]
         },

--- a/crates/data-dict/tests/snapshots/translate__a_definition_reference_is_not_a_column.snap
+++ b/crates/data-dict/tests/snapshots/translate__a_definition_reference_is_not_a_column.snap
@@ -1,0 +1,47 @@
+---
+source: crates/data-dict/tests/translate.rs
+expression: "translate_json(indoc!\n{r#\"\n        description: Each row is an order.\n        tables:\n          - name: orders\n            columns:\n              - name: tile_size\n                type: string\n                examples: [\"Enterprise-1\"]\n              - name: order_total\n                type: number(quantity)\n                units: usd\n                range: [0, .inf]\n            constraints:\n              - assert: is_enterprise AND order_total > 0\n            definitions:\n              - name: is_enterprise\n                expr: tile_size IN ('Enterprise-1')\n    \"#})"
+---
+[
+  {
+    "expr": "is_enterprise AND order_total > 0",
+    "table": "orders",
+    "type": "boolean",
+    "columns": [
+      "order_total"
+    ],
+    "definitions": [
+      "is_enterprise"
+    ],
+    "translations": [
+      {
+        "target": "SQL(duckdb)",
+        "code": "\"is_enterprise\" AND \"order_total\" > 0",
+        "notes": [
+          "DuckDB compares a NaN as equal to itself and greater than every number, where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "R(tidyverse)",
+        "code": "is_enterprise & order_total > 0L",
+        "notes": [
+          "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "R(base)",
+        "code": "is_enterprise & order_total > 0L",
+        "notes": [
+          "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "R(data.table)",
+        "code": "is_enterprise & order_total > 0L",
+        "notes": [
+          "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      }
+    ]
+  }
+]

--- a/crates/data-dict/tests/snapshots/validate_data__assertion_referencing_a_definition_is_evaluated.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__assertion_referencing_a_definition_is_evaluated.snap
@@ -1,0 +1,29 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    constraints:
+      - assert: doubled > 0
+    definitions:
+      - name: doubled
+        expr: a * 2
+    columns:
+      - name: a
+        type: number(quantity)
+        range: [-1000000, 1000000]
+      - name: b
+        type: number(quantity)
+        range: [-1000000, 1000000]
+────────────────────────────────────────
+error[D07]: An assertion must hold for every row.
+  --> dict.yaml:8:17
+   |
+LL |   - name: t
+...
+LL |       - assert: doubled > 0
+   |                 ^^^^^^^^^^^ is false for 1 row: 2 (a=-2)

--- a/crates/data-dict/tests/snapshots/validate_data__assertion_referencing_a_nested_definition_is_evaluated.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__assertion_referencing_a_nested_definition_is_evaluated.snap
@@ -1,0 +1,31 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    constraints:
+      - assert: not_neg
+    definitions:
+      - name: neg
+        expr: a < 0
+      - name: not_neg
+        expr: NOT(neg)
+    columns:
+      - name: a
+        type: number(quantity)
+        range: [-1000000, 1000000]
+      - name: b
+        type: number(quantity)
+        range: [-1000000, 1000000]
+────────────────────────────────────────
+error[D07]: An assertion must hold for every row.
+  --> dict.yaml:8:17
+   |
+LL |   - name: t
+...
+LL |       - assert: not_neg
+   |                 ^^^^^^^ is false for 1 row: 2 (a=-2)

--- a/crates/data-dict/tests/snapshots/validate_spec__assertion_plus_filter_two_columns_selections.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__assertion_plus_filter_two_columns_selections.snap
@@ -1,0 +1,27 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: survey
+    columns:
+      - name: q1
+        type: number(ordinal)
+        range: [1, 5]
+      - name: q2
+        type: number(ordinal)
+        range: [1, 5]
+    definitions:
+      - name: all_present
+        expr: COLUMNS('q[1-2]') IS NOT NULL
+    constraints:
+      - assert: COLUMNS(*) IS NOT NULL AND all_present
+────────────────────────────────────────
+error[S21]: An expression may use at most one `COLUMNS(...)`.
+  --> dict.yaml:16:44
+   |
+LL |   - name: survey
+...
+LL |       - assert: COLUMNS(*) IS NOT NULL AND all_present
+   |                                            ^^^^^^^^^^^ recursively includes `COLUMNS(...)`

--- a/crates/data-dict/tests/snapshots/validate_spec__definition_non_filter_via_reference.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__definition_non_filter_via_reference.snap
@@ -1,0 +1,28 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: survey
+    columns:
+      - name: q1
+        type: number(ordinal)
+        range: [1, 5]
+      - name: q2
+        type: number(ordinal)
+        range: [1, 5]
+    definitions:
+      - name: filt
+        expr: COLUMNS(*) > 0
+      - name: bad
+        expr: CASE WHEN filt THEN 1 ELSE 0 END
+────────────────────────────────────────
+error[S21]: An expression using `COLUMNS(...)` must be a boolean filter.
+  --> dict.yaml:16:25
+   |
+LL |   - name: survey
+...
+LL |       - name: bad
+LL |         expr: CASE WHEN filt THEN 1 ELSE 0 END
+   |                         ^^^^ `filt` recursively includes `COLUMNS(...)` and the expression is not a boolean

--- a/crates/data-dict/tests/snapshots/validate_spec__definition_own_selection_plus_reference.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__definition_own_selection_plus_reference.snap
@@ -1,0 +1,28 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: survey
+    columns:
+      - name: q1
+        type: number(ordinal)
+        range: [1, 5]
+      - name: q2
+        type: number(ordinal)
+        range: [1, 5]
+    definitions:
+      - name: f1
+        expr: COLUMNS('q1') IS NOT NULL
+      - name: f2
+        expr: f1 AND COLUMNS('q2') IS NOT NULL
+────────────────────────────────────────
+error[S21]: An expression may use at most one `COLUMNS(...)`.
+  --> dict.yaml:16:15
+   |
+LL |   - name: survey
+...
+LL |       - name: f2
+LL |         expr: f1 AND COLUMNS('q2') IS NOT NULL
+   |               ^^ recursively includes `COLUMNS(...)`

--- a/crates/data-dict/tests/snapshots/validate_spec__definition_unparseable_reference_no_cascade.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__definition_unparseable_reference_no_cascade.snap
@@ -1,0 +1,24 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: orders
+    columns:
+      - name: order_total
+        type: number(quantity)
+        range: [0, 10000]
+    definitions:
+      - name: broken
+        expr: 1 +
+      - name: uses_broken
+        expr: broken + 1
+    constraints:
+      - assert: order_total <= uses_broken
+────────────────────────────────────────
+error[S19]: 
+  --> dict.yaml:11:18
+   |
+LL |         expr: 1 +
+   |                  ^ definition expression does not parse: expected an expression

--- a/crates/data-dict/tests/snapshots/validate_spec__s31_todo_at_every_level.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__s31_todo_at_every_level.snap
@@ -23,6 +23,10 @@ tables:
             type: string
             examples: ['97201']
             todo: Is this always 5 digits?
+    definitions:
+      - name: is_active
+        expr: status = 'active'
+        todo: Confirm the active status codes.
   - name: category
     columns:
       - name: id
@@ -68,7 +72,16 @@ LL |           - name: zip
 LL |             todo: Is this always 5 digits?
    |                   ^^^^^^^^^^^^^^^^^^^^^^^^ unresolved todo
 warning[S31]: Every `todo` must be resolved.
-  --> dict.yaml:36:11
+  --> dict.yaml:26:15
+   |
+LL |   - name: food
+...
+LL |       - name: is_active
+LL |         expr: status = 'active'
+LL |         todo: Confirm the active status codes.
+   |               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ unresolved todo
+warning[S31]: Every `todo` must be resolved.
+  --> dict.yaml:40:11
    |
 LL |   - join: category.food_id = food.id
 LL |     cardinality: many-to-one

--- a/crates/data-dict/tests/translate.rs
+++ b/crates/data-dict/tests/translate.rs
@@ -1,0 +1,44 @@
+//! Integration tests for `data_dict::translate`; see `site/export.md` for the
+//! shape the output shares with the export document.
+
+mod common;
+use common::{temp_dir, write_dict};
+
+use data_dict::translate::{Options, translate};
+use indoc::indoc;
+
+fn translate_json(yaml: &str) -> String {
+    let path = write_dict(&temp_dir(), yaml);
+    let translations = translate(&path, &Options::default()).unwrap_or_else(|problems| {
+        panic!(
+            "translate should succeed, got:\n{}",
+            problems.render(common::SNAPSHOT_STYLE).join("\n")
+        )
+    });
+    serde_json::to_string_pretty(&translations).unwrap()
+}
+
+/// A constraint that references a definition lists it under `definitions`,
+/// not `columns` — only loadable columns appear in `columns`, matching the
+/// export document.
+#[test]
+fn a_definition_reference_is_not_a_column() {
+    insta::assert_snapshot!(translate_json(indoc! {r#"
+        description: Each row is an order.
+        tables:
+          - name: orders
+            columns:
+              - name: tile_size
+                type: string
+                examples: ["Enterprise-1"]
+              - name: order_total
+                type: number(quantity)
+                units: usd
+                range: [0, .inf]
+            constraints:
+              - assert: is_enterprise AND order_total > 0
+            definitions:
+              - name: is_enterprise
+                expr: tile_size IN ('Enterprise-1')
+    "#}));
+}

--- a/crates/data-dict/tests/validate_data.rs
+++ b/crates/data-dict/tests/validate_data.rs
@@ -2123,6 +2123,38 @@ fn an_assertion_that_holds_is_silent() {
     assert_eq!(validate_data(&yaml, None).status(), Status::Ok);
 }
 
+// A definition reference becomes the definition's expression to evaluate —
+// the data has no such column — so the assertion is checked, not dropped.
+#[test]
+fn assertion_referencing_a_definition_is_evaluated() {
+    let constraints = format!(
+        "{}\n    definitions:\n      - name: doubled\n        expr: a * 2",
+        assertion("doubled > 0")
+    );
+    let yaml = build_asserted(&[1, 2, 3], &[None, None, None], &constraints);
+    assert_eq!(validate_data(&yaml, None).status(), Status::Ok);
+
+    let yaml = build_asserted(&[1, -2, 3], &[None, None, None], &constraints);
+    let diagnostic = asserted(&yaml);
+    diagnostic.assert_contains(&["D07", "is false for 1 row", "(a=-2)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+// A definition building on another definition expands transitively.
+#[test]
+fn assertion_referencing_a_nested_definition_is_evaluated() {
+    let constraints = format!(
+        "{}\n    definitions:\n      - name: neg\n        expr: a < 0\n      - name: not_neg\n        expr: NOT(neg)",
+        assertion("not_neg")
+    );
+    let yaml = build_asserted(&[1, -2, 3], &[None, None, None], &constraints);
+    let diagnostic = asserted(&yaml);
+    diagnostic.assert_contains(&["D07", "is false for 1 row", "(a=-2)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
 #[test]
 fn a_null_operand_passes() {
     // Only `false` is a violation: a comparison against a null is null, which

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -1115,6 +1115,10 @@ fn s31_todo_at_every_level() {
                     type: string
                     examples: ['97201']
                     todo: Is this always 5 digits?
+            definitions:
+              - name: is_active
+                expr: status = 'active'
+                todo: Confirm the active status codes.
           - name: category
             columns:
               - name: id
@@ -2724,6 +2728,32 @@ fn definition_broken_reference_no_cascade() {
     "});
     diagnostic.assert_contains(&["S21", "LENGTH"]);
     assert_eq!(diagnostic.rendered.matches("S21").count(), 1);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+// A definition whose expression doesn't parse is S19 at its own location;
+// definitions and assertions referencing it see the permissive `Any` type
+// rather than a cascading S20.
+#[test]
+fn definition_unparseable_reference_no_cascade() {
+    let diagnostic = failing_dict(indoc! {"
+        tables:
+          - name: orders
+            columns:
+              - name: order_total
+                type: number(quantity)
+                range: [0, 10000]
+            definitions:
+              - name: broken
+                expr: 1 +
+              - name: uses_broken
+                expr: broken + 1
+            constraints:
+              - assert: order_total <= uses_broken
+    "});
+    diagnostic.assert_contains(&["S19", "does not parse"]);
+    assert!(!diagnostic.rendered.contains("S20"));
     #[cfg(unix)]
     assert_snapshot!(diagnostic);
 }

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -2866,6 +2866,54 @@ fn assertion_using_definitions_ok() {
     "});
 }
 
+// A filter definition's COLUMNS(...) is the assertion's one allowed selection
+// once the reference is substituted in.
+#[test]
+fn assertion_using_columns_filter_ok() {
+    assert_clean_dict(indoc! {"
+        tables:
+          - name: survey
+            columns:
+              - name: q1
+                type: number(ordinal)
+                range: [1, 5]
+              - name: q2
+                type: number(ordinal)
+                range: [1, 5]
+            definitions:
+              - name: all_present
+                expr: COLUMNS('q[1-2]') IS NOT NULL
+            constraints:
+              - assert: all_present
+    "});
+}
+
+// The at-most-one COLUMNS(...) rule binds after definition references are
+// substituted in: the assertion's own selection and the filter's combine to
+// two, which evaluation couldn't resolve to a single selection.
+#[test]
+fn assertion_plus_filter_two_columns_selections() {
+    let diagnostic = failing_dict(indoc! {"
+        tables:
+          - name: survey
+            columns:
+              - name: q1
+                type: number(ordinal)
+                range: [1, 5]
+              - name: q2
+                type: number(ordinal)
+                range: [1, 5]
+            definitions:
+              - name: all_present
+                expr: COLUMNS('q[1-2]') IS NOT NULL
+            constraints:
+              - assert: COLUMNS(*) IS NOT NULL AND all_present
+    "});
+    diagnostic.assert_contains(&["S21", "at most one `COLUMNS(...)`", "recursively includes"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
 // An assertion referencing a name that is neither a column nor a definition.
 #[test]
 fn assertion_unknown_name_with_definitions() {

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -2914,6 +2914,78 @@ fn assertion_plus_filter_two_columns_selections() {
     assert_snapshot!(diagnostic);
 }
 
+// A selection that arrives through a reference still makes the definition a
+// filter: building a non-boolean value on one is S21.
+#[test]
+fn definition_non_filter_via_reference() {
+    let diagnostic = failing_dict(indoc! {"
+        tables:
+          - name: survey
+            columns:
+              - name: q1
+                type: number(ordinal)
+                range: [1, 5]
+              - name: q2
+                type: number(ordinal)
+                range: [1, 5]
+            definitions:
+              - name: filt
+                expr: COLUMNS(*) > 0
+              - name: bad
+                expr: CASE WHEN filt THEN 1 ELSE 0 END
+    "});
+    diagnostic.assert_contains(&["S21", "must be a boolean filter", "recursively includes"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+// A definition's own selection plus one brought in by a reference is two
+// selections: over the budget of one.
+#[test]
+fn definition_own_selection_plus_reference() {
+    let diagnostic = failing_dict(indoc! {"
+        tables:
+          - name: survey
+            columns:
+              - name: q1
+                type: number(ordinal)
+                range: [1, 5]
+              - name: q2
+                type: number(ordinal)
+                range: [1, 5]
+            definitions:
+              - name: f1
+                expr: COLUMNS('q1') IS NOT NULL
+              - name: f2
+                expr: f1 AND COLUMNS('q2') IS NOT NULL
+    "});
+    diagnostic.assert_contains(&["S21", "at most one `COLUMNS(...)`", "recursively includes"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+// A boolean definition building on a filter is itself a filter; the single
+// selection travels with it.
+#[test]
+fn definition_filter_via_reference_ok() {
+    assert_clean_dict(indoc! {"
+        tables:
+          - name: survey
+            columns:
+              - name: q1
+                type: number(ordinal)
+                range: [1, 5]
+              - name: q2
+                type: number(ordinal)
+                range: [1, 5]
+            definitions:
+              - name: all_present
+                expr: COLUMNS('q[1-2]') IS NOT NULL
+              - name: any_missing
+                expr: NOT(all_present)
+    "});
+}
+
 // An assertion referencing a name that is neither a column nor a definition.
 #[test]
 fn assertion_unknown_name_with_definitions() {

--- a/schema.yaml
+++ b/schema.yaml
@@ -42,8 +42,8 @@ object:
     origin: string
 
     # A note of work that remains to be done. Accepted at every describing
-    # level (dataset, table, column, field, relationship); each remaining
-    # note is reported by S31.
+    # level (dataset, table, column, field, relationship, definition); each
+    # remaining note is reported by S31.
     todo: string
 
     tables:
@@ -167,6 +167,7 @@ object:
                     label: string
                     description: string
                     details: string
+                    todo: string
 
     relationships:
       arrayOf:

--- a/site/export.md
+++ b/site/export.md
@@ -1,6 +1,6 @@
 # Export
 
-`data-dict` can render a `data-dict.yaml` file to JSON, resolving everything the validator already computes internally — parsed types, constraint flags, joins, assertions — so downstream tools don't need to re-implement any of the spec's parsing or inference rules.
+`data-dict` can render a `data-dict.yaml` file to JSON, resolving everything the validator already computes internally — parsed types, constraint flags, joins, assertions, definitions — so downstream tools don't need to re-implement any of the spec's parsing or inference rules.
 
 ## Two levels
 
@@ -55,7 +55,8 @@ Prose fields — every `description`, `details`, and `todo`, and each glossary `
   "rows?": 123,                  // the source data's row count; export-data only,
                                  // absent when the table's source wasn't profiled
   "columns": [ Column ],
-  "constraints?": [ Assertion ]  // table-level `assert` entries
+  "constraints?": [ Assertion ], // table-level `assert` entries
+  "definitions?": [ Definition ] // the table's `definitions`, resolved
 }
 ```
 
@@ -104,6 +105,7 @@ Both `references` and `referenced_by` are derived from `relationships`, not read
   "expression": "string",         // original `assert` text
   "description?": "string",
   "columns": ["string", ...],     // every column (and struct field, dotted) the expression references
+  "definitions?": ["string", ...], // every definition of the same table it references
   "translations?": [ Translation ]
 }
 ```
@@ -112,7 +114,7 @@ Both `references` and `referenced_by` are derived from `relationships`, not read
 
 ### Translation
 
-A `Translation` is the assertion's expression rendered as a bare predicate in one target language — the same translation `translate` produces, so a consumer can embed the check directly in that language's pipeline rather than re-parsing `expression`. One entry per target the exporter can produce; a target that can't express the assertion still appears, carrying the reason instead of code:
+A `Translation` is the expression rendered as a bare expression in one target language — the same translation `translate` produces, so a consumer can embed it directly in that language's pipeline rather than re-parsing `expression`. For an assertion the rendering is a predicate; for a definition it computes the definition's value, so a metric's translation is an aggregate expression, embeddable only where the target aggregates (a `SELECT` list, a `summarise()`). An expression that builds on another definition is not translated: composing it is the consumer's job, from the referenced definition's own translations (named by `definitions`), so every target carries the reason in `error`. One entry per target the exporter can produce; a target that can't express the expression still appears, carrying the reason instead of code:
 
 ```jsonc
 {
@@ -123,6 +125,31 @@ A `Translation` is the assertion's expression rendered as a bare predicate in on
                                   // expression's own semantics; absent when it agrees exactly
 }
 ```
+
+### Definition
+
+A `Definition` is one of a table's [`definitions`](spec.md#definitions) — a named metric, filter, or derived value — with its expression's kind, value type, and references resolved:
+
+```jsonc
+{
+  "name": "string",
+  "label?": "string",
+  "description?": "string",
+  "details?": "string",
+  "expression": "string",          // original `expr` text
+  "kind": "filter" | "metric" | "derived",
+  // read off the expression's type and shape, as the spec defines: a boolean
+  // row-level expression is a filter, an aggregate or constant a metric,
+  // anything else a derived value
+  "type?": "string",               // the expression's value type:
+                                   // "number" | "string" | "boolean" | "date" | "datetime" | "interval"
+  "columns": ["string", ...],      // every column (and struct field, dotted) the expression reads
+  "definitions?": ["string", ...], // other definitions of the same table it builds on
+  "translations?": [ Translation ]
+}
+```
+
+`columns` and `definitions` list direct references only, in first-appearance order — a definition that builds on another definition names it under `definitions`, and the columns that definition reads appear on its own entry.
 
 ### Relationship
 

--- a/site/export.md
+++ b/site/export.md
@@ -114,7 +114,7 @@ Both `references` and `referenced_by` are derived from `relationships`, not read
 
 ### Translation
 
-A `Translation` is the expression rendered as a bare expression in one target language — the same translation `translate` produces, so a consumer can embed it directly in that language's pipeline rather than re-parsing `expression`. For an assertion the rendering is a predicate; for a definition it computes the definition's value, so a metric's translation is an aggregate expression, embeddable only where the target aggregates (a `SELECT` list, a `summarise()`). An expression that builds on another definition is not translated: composing it is the consumer's job, from the referenced definition's own translations (named by `definitions`), so every target carries the reason in `error`. One entry per target the exporter can produce; a target that can't express the expression still appears, carrying the reason instead of code:
+A `Translation` is the expression rendered as a bare expression in one target language — the same translation `translate` produces, so a consumer can embed it directly in that language's pipeline rather than re-parsing `expression`. For an assertion the rendering is a predicate; for a definition it computes the definition's value, so a metric's translation is an aggregate expression, embeddable only where the target aggregates (a `SELECT` list, a `summarise()`). A reference to another definition renders as a bare name, as if it were a column — substituting the referenced definition's own translation (named by `definitions`) is the consumer's job. One entry per target the exporter can produce; a target that can't express the expression still appears, carrying the reason instead of code:
 
 ```jsonc
 {

--- a/site/expressions.md
+++ b/site/expressions.md
@@ -465,7 +465,7 @@ constraints:
 
 Three rules bound the feature:
 
-* **At most one `COLUMNS(...)`** may appear in an expression, so there's no ambiguity about how two selections would combine.
+* **At most one `COLUMNS(...)`** may appear in an expression, so there's no ambiguity about how two selections would combine. A selection inside a referenced [definition](spec.md#definitions) counts toward the expression that references it, so an assertion can't pair its own `COLUMNS(...)` with a filter definition's.
 * **Every selected column must fit the way the expression uses it**, since the predicate is applied to each in turn. `LENGTH(COLUMNS('name_.*'))` requires that each matched column is a string, just as a bare column reference would.
 * **A regex that matches nothing is a warning.** It's almost always a typo, and the expression would otherwise hold vacuously. `COLUMNS(*)` and an explicit list can't trigger it — an empty list isn't expressible, and an unknown name in a list is an error rather than a warning.
 

--- a/site/spec.md
+++ b/site/spec.md
@@ -368,8 +368,10 @@ Each entry is a map with:
 The kind of a definition is read off the expression's type and [shape](expressions.md#shapes):
 
 * A boolean, `row`-shape expression is a **filter**, a named segment of the table's rows.
-* A `agg`- or `const`-shape expression is a **metric**, a single value for a group of rows. 
+* A `agg`- or `const`-shape expression is a **metric**, a single value summarising the rows it's evaluated against.
 * Any other `row`-shape expression is a **derived** value, with one value for each row, which can be used to generate a column. A filter is also a derived value.
+
+The expression language has no grouping of its own: a metric is defined over whatever rows the consumer evaluates it against, and any grouping — SQL's `GROUP BY`, dplyr's `.by =`, a dashboard's drill-down — is up to the host environment to supply.
 
 ```yaml
 tables:

--- a/site/spec.md
+++ b/site/spec.md
@@ -363,6 +363,7 @@ Each entry is a map with:
 * `name` (required): the definition's name. Must be non-empty and unique within the table. Definitions and columns share a namespace: a definition's name must not match any column name in the same table.
 * `expr` (required): an expression in the [expression language](expressions.md). Unlike an assertion, it need not be boolean.
 * `label`, `description`, `details`: human-readable documentation for the definition; see [Name, label, description & details](#name-label-description--details).
+* `todo`: a note of work that remains before the definition is complete; see [Todo](#todo).
 
 The kind of a definition is read off the expression's type and [shape](expressions.md#shapes):
 
@@ -481,6 +482,6 @@ version:
     - Looks like an enum — confirm the full set of `values` and switch the `type`.
 ```
 
-`todo` may appear at every level that describes something: the top level (the dataset), a table, a column, a struct field, and a relationship. Put each note on the thing it's about, so the work travels with its subject.
+`todo` may appear at every level that describes something: the top level (the dataset), a table, a column, a struct field, a relationship, and a definition. Put each note on the thing it's about, so the work travels with its subject.
 
 Every remaining `todo` is reported when the spec is validated (see S31 in [validation](validation.md)), so a dictionary announces its own unfinished work each time it's checked. It's reported as a warning rather than an error, so an unfinished dictionary can still be validated against its data — but you should resolve every `todo` before you consider the dictionary finished.


### PR DESCRIPTION
A table's `definitions` now appear in the JSON export (`export-spec`/`export-data`), documented in `site/export.md`:

- Each definition exports with its `kind` (`filter`/`metric`/`derived`, read off the expression's resolved type and shape), its value `type`, and its references resolved — `columns` it reads and `definitions` of the same table it builds on.
- Definitions carry `translations` like assertions do. A reference to another definition renders as a bare name, as if it were a column (the IR lowerer resolves it through the environment's definition types), so substituting the referenced definition's own translation is the client's job. Assertions referencing definitions get the same treatment, and assertion `columns` no longer misreport a referenced definition as a column (new `definitions` key). The `translate` CLI checks and lowers against the same definition-aware environment.
- New `resolve_definitions` in `validate_spec.rs` is a silent variant of the validation-time resolution, reused by the export and the CLI.

Tests: targeted assertions plus a full-document snapshot (`export__definitions_export_snapshot.snap`) showing the shape end to end. Full workspace suite, clippy, and fmt pass.

Open question flagged for follow-up: filter translations use assertion `CHECK` semantics (null passes), which may not suit row-selection use.

Fixes #134