### PR TITLE
Error clearly when $version names an unsupported spec version

### DIFF
--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -35,6 +35,10 @@ pub const LEARN_MORE_URL: &str = "https://data-dict.tidyverse.org/";
 /// The spec version this validator implements, suggested for a missing `$version`.
 pub const SPEC_VERSION: &str = "0.1.0";
 
+/// The first spec version ever released. A `$version` below this is invalid
+/// outright; anything from here up to [`SPEC_VERSION`] is accepted.
+const FIRST_SPEC_VERSION: &str = "0.1.0";
+
 const SCHEMA_YAML: &str = include_str!("../../../schema.yaml");
 const FIELD_SCHEMA_YAML: &str = include_str!("../../../schema-field.yaml");
 
@@ -1758,10 +1762,11 @@ fn validate_s18_version_present(root: &YamlWithSourceInfo, out: &mut ProblemSet)
 
 /// Error when the document's `$version` names a spec version this validator
 /// doesn't support. The schema admits any string so the comparison lands here
-/// with a clear message: a higher version means the tool is older than the
-/// document, so the hint points at upgrading data-dict; a lower one is invalid
-/// outright, since spec numbering starts at `0.1.0`. Comparison uses the
-/// numeric core, ignoring any pre-release/build suffix.
+/// with a clear message: a version above [`SPEC_VERSION`] means the tool is
+/// older than the document, so the hint points at upgrading data-dict; one
+/// below [`FIRST_SPEC_VERSION`] is invalid outright, since spec numbering
+/// starts there. Anything in between is accepted. Comparison uses the numeric
+/// core, ignoring any pre-release/build suffix.
 fn validate_s32_spec_version(root: &YamlWithSourceInfo, out: &mut ProblemSet) {
     let Some(entries) = root.as_hash() else {
         return;
@@ -1777,8 +1782,9 @@ fn validate_s32_spec_version(root: &YamlWithSourceInfo, out: &mut ProblemSet) {
     let spans = [version.key_span.clone(), version.value_span.clone()];
     let supported =
         parse_version_core(SPEC_VERSION).expect("SPEC_VERSION is a valid version number");
+    let first =
+        parse_version_core(FIRST_SPEC_VERSION).expect("FIRST_SPEC_VERSION is a valid version");
     match text.and_then(|t| parse_version_core(t).map(|core| (t, core))) {
-        Some((_, core)) if core == supported => {}
         Some((t, core)) if core > supported => {
             out.push_spec_error(
                 "S32",
@@ -1790,14 +1796,15 @@ fn validate_s32_spec_version(root: &YamlWithSourceInfo, out: &mut ProblemSet) {
             );
             out.hint_last("Upgrade data-dict to the latest version.");
         }
-        Some((t, _)) => {
+        Some((t, core)) if core < first => {
             out.push_spec_error(
                 "S32",
-                format!("Spec version numbering starts at `{SPEC_VERSION}`."),
+                format!("Spec version numbering starts at `{FIRST_SPEC_VERSION}`."),
                 format!("`$version` is `{t}`, which is not a valid spec version"),
                 spans,
             );
         }
+        Some(_) => {}
         None => {
             out.push_spec_error(
                 "S32",

--- a/crates/data-dict/src/validate_spec.rs
+++ b/crates/data-dict/src/validate_spec.rs
@@ -201,6 +201,7 @@ pub(crate) fn validate_and_lower(
     validate_s09_learn_more(doc, out);
     validate_s17_version(doc, out);
     validate_s18_version_present(doc, out);
+    validate_s32_spec_version(doc, out);
     out.sort();
 
     if out.status().failed() {
@@ -1724,8 +1725,7 @@ fn validate_s17_version(root: &YamlWithSourceInfo, out: &mut ProblemSet) {
 // --- S18 --------------------------------------------------------------
 
 /// Error when the document omits the required top-level `$version` key. The
-/// schema leaves this key optional so its absence lands here with a patch
-/// (a present-but-wrong value is still an enum error at the schema level).
+/// schema leaves this key optional so its absence lands here with a patch.
 /// Like S09, the missing key has no location of its own, so the error is
 /// anchored at the document's first character.
 fn validate_s18_version_present(root: &YamlWithSourceInfo, out: &mut ProblemSet) {
@@ -1752,6 +1752,78 @@ fn validate_s18_version_present(root: &YamlWithSourceInfo, out: &mut ProblemSet)
         replacement: format!("$version: {SPEC_VERSION}\n"),
         span: insert_at,
     });
+}
+
+// --- S32 --------------------------------------------------------------
+
+/// Error when the document's `$version` names a spec version this validator
+/// doesn't support. The schema admits any string so the comparison lands here
+/// with a clear message: a higher version means the tool is older than the
+/// document, so the hint points at upgrading data-dict; a lower one is invalid
+/// outright, since spec numbering starts at `0.1.0`. Comparison uses the
+/// numeric core, ignoring any pre-release/build suffix.
+fn validate_s32_spec_version(root: &YamlWithSourceInfo, out: &mut ProblemSet) {
+    let Some(entries) = root.as_hash() else {
+        return;
+    };
+    let Some(version) = entries
+        .iter()
+        .find(|e| e.key.yaml.as_str() == Some("$version"))
+    else {
+        return;
+    };
+
+    let text = version.value.yaml.as_str();
+    let spans = [version.key_span.clone(), version.value_span.clone()];
+    let supported =
+        parse_version_core(SPEC_VERSION).expect("SPEC_VERSION is a valid version number");
+    match text.and_then(|t| parse_version_core(t).map(|core| (t, core))) {
+        Some((_, core)) if core == supported => {}
+        Some((t, core)) if core > supported => {
+            out.push_spec_error(
+                "S32",
+                "This document conforms to a newer version of the data-dict spec than this validator supports.",
+                format!(
+                    "`$version` is `{t}`, but this version of data-dict supports up to `{SPEC_VERSION}`"
+                ),
+                spans,
+            );
+            out.hint_last("Upgrade data-dict to the latest version.");
+        }
+        Some((t, _)) => {
+            out.push_spec_error(
+                "S32",
+                format!("Spec version numbering starts at `{SPEC_VERSION}`."),
+                format!("`$version` is `{t}`, which is not a valid spec version"),
+                spans,
+            );
+        }
+        None => {
+            out.push_spec_error(
+                "S32",
+                "A `$version` must have three dot-separated numeric components, with an optional pre-release/build suffix.",
+                match text {
+                    Some(t) => format!("`{t}` is not a valid version number"),
+                    None => "is not a valid version number".to_string(),
+                },
+                spans,
+            );
+        }
+    }
+}
+
+/// The numeric `MAJOR.MINOR.PATCH` core of a version number, ignoring any
+/// pre-release/build suffix; `None` when `s` is not a valid version number.
+fn parse_version_core(s: &str) -> Option<(u64, u64, u64)> {
+    if !is_version_number(s) {
+        return None;
+    }
+    let mut parts = s.split(['+', '-']).next()?.split('.');
+    Some((
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+        parts.next()?.parse().ok()?,
+    ))
 }
 
 /// A version `number` per the spec: three dot-separated numeric components

--- a/crates/data-dict/tests/snapshots/validate_spec__malformed_spec_version.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__malformed_spec_version.snap
@@ -1,0 +1,11 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: latest
+tables: []
+────────────────────────────────────────
+error[S32]: A `$version` must have three dot-separated numeric components, with an optional pre-release/build suffix.
+  --> dict.yaml:1:11
+   |
+LL | $version: latest
+   |           ^^^^^^ `latest` is not a valid version number

--- a/crates/data-dict/tests/snapshots/validate_spec__newer_spec_version.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__newer_spec_version.snap
@@ -1,0 +1,13 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: 99.0.0
+tables: []
+────────────────────────────────────────
+error[S32]: This document conforms to a newer version of the data-dict spec than this validator supports.
+  --> dict.yaml:1:11
+   |
+LL | $version: 99.0.0
+   |           ^^^^^^ `$version` is `99.0.0`, but this version of data-dict supports up to `0.1.0`
+   |
+   = help: Upgrade data-dict to the latest version.

--- a/crates/data-dict/tests/snapshots/validate_spec__older_spec_version.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__older_spec_version.snap
@@ -1,0 +1,11 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: 0.0.9
+tables: []
+────────────────────────────────────────
+error[S32]: Spec version numbering starts at `0.1.0`.
+  --> dict.yaml:1:11
+   |
+LL | $version: 0.0.9
+   |           ^^^^^ `$version` is `0.0.9`, which is not a valid spec version

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -336,6 +336,30 @@ fn missing_version() {
 }
 
 #[test]
+fn newer_spec_version() {
+    let diagnostic = failing_raw("$version: 99.0.0\ntables: []\n");
+    diagnostic.assert_contains(&["S32", "newer", "Upgrade data-dict"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+#[test]
+fn older_spec_version() {
+    let diagnostic = failing_raw("$version: 0.0.9\ntables: []\n");
+    diagnostic.assert_contains(&["S32", "starts at `0.1.0`", "not a valid spec version"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+#[test]
+fn malformed_spec_version() {
+    let diagnostic = failing_raw("$version: latest\ntables: []\n");
+    diagnostic.assert_contains(&["S32", "`latest` is not a valid version number"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+#[test]
 fn unknown_top_level_key() {
     let diagnostic = failing_dict("bogus: 1\n");
     diagnostic.assert_contains(&["Unknown property 'bogus'"]);

--- a/schema.yaml
+++ b/schema.yaml
@@ -21,11 +21,9 @@ object:
 
     # Required, but its absence is checked by S18 (in validate_spec.rs) rather
     # than the schema, so the omission carries a patch suggesting `$version`.
-    # A present-but-wrong value is still rejected here by the enum.
-    "$version":
-      enum: [0.1.0]
-      description: >
-        Version of the data-dict.yaml spec this document conforms to.
+    # The version of the data-dict.yaml spec the document conforms to.
+    # Checked against the version that library supports.
+    "$version": string
 
     # Optional in the schema (its absence is a warning, not an error — see
     # S09 in validate_spec.rs); a URL where readers can learn about the format.

--- a/site/validation.md
+++ b/site/validation.md
@@ -61,7 +61,7 @@ A validator reports two severities of problem: **errors** and **warnings**. The 
 | S29 | Invalid constraint on list or struct | E | A `primary_key`, `foreign_key`, or `unique` constraint appears on a `list` or `struct` column. (There is no such check for fields: a field can't carry `constraints` at all, which the schema enforces structurally.) |
 | S30 | Nested aggregate | E | An aggregate function's argument contains another aggregate call, as in `AVG(MIN(x))`: an aggregate folds one value per row, and another aggregate gives it a single value. This is the only [shape](expressions.md#shapes) an expression can get wrong — every other combination is legal, including mixing a row-level subexpression with an aggregate one (`value <= 2 * MIN(value)`). |
 | S31 | Unresolved todo | W | A `todo` key remains in the dictionary. Each one is reported at its location. Delete the key once the work it records is done. |
-| S32 | Unsupported spec version | E | The document's `$version` is not the spec version this validator supports (currently `0.1.0`): it is not a valid version number, it predates the first spec version (`0.1.0`), or it names a newer spec. A newer version means the tool is older than the document — upgrade `data-dict`. |
+| S32 | Unsupported spec version | E | The document's `$version` names a spec version this validator can't accept: it is not a valid version number, it predates the first spec version (`0.1.0`), or it is newer than the version the validator supports (currently `0.1.0`). A newer version means the tool is older than the document — upgrade `data-dict`. Versions between the first and the supported one are accepted. |
 
 : {tbl-colwidths="[7,23,5,65]"}
 

--- a/site/validation.md
+++ b/site/validation.md
@@ -61,6 +61,7 @@ A validator reports two severities of problem: **errors** and **warnings**. The 
 | S29 | Invalid constraint on list or struct | E | A `primary_key`, `foreign_key`, or `unique` constraint appears on a `list` or `struct` column. (There is no such check for fields: a field can't carry `constraints` at all, which the schema enforces structurally.) |
 | S30 | Nested aggregate | E | An aggregate function's argument contains another aggregate call, as in `AVG(MIN(x))`: an aggregate folds one value per row, and another aggregate gives it a single value. This is the only [shape](expressions.md#shapes) an expression can get wrong — every other combination is legal, including mixing a row-level subexpression with an aggregate one (`value <= 2 * MIN(value)`). |
 | S31 | Unresolved todo | W | A `todo` key remains in the dictionary. Each one is reported at its location. Delete the key once the work it records is done. |
+| S32 | Unsupported spec version | E | The document's `$version` is not the spec version this validator supports (currently `0.1.0`): it is not a valid version number, it predates the first spec version (`0.1.0`), or it names a newer spec. A newer version means the tool is older than the document — upgrade `data-dict`. |
 
 : {tbl-colwidths="[7,23,5,65]"}
 


### PR DESCRIPTION
Closes #216.

Adds a new **S32** check: the document's `$version` must match the spec version this validator supports (currently `0.1.0`, compared on the numeric core, ignoring pre-release/build suffixes).

- **Higher version** — the tool is older than the document, so the error recommends upgrading: `help: Upgrade data-dict to the latest version.`
- **Lower version** — invalid outright, since spec version numbering starts at `0.1.0`. We'll need to figure out what if we ever bump the version, but I assume it'll be support older versions, while recommending you upgrade (and providing tools to do that).
- **Non-version string** — reported as malformed.

The schema's `enum: [0.1.0]` constraint on `$version` is dropped so all three cases reach the semantic check with a clear message instead of a generic structural failure. Includes the `validation.md` registry row and snapshot tests for each case.