### PR TITLE
Improve rendered dictionary page readability and accessibility

### DIFF
--- a/crates/data-dict-cli/render/app.css
+++ b/crates/data-dict-cli/render/app.css
@@ -8,11 +8,15 @@
   --ink: light-dark(#1c2430, #e3e6ea);
   --ink-soft: light-dark(#5b6675, #a3acb7);
   --ink-faint: light-dark(#66707e, #8d97a2);
-  --paper: light-dark(#f1eee8, #14181c);
-  --card: light-dark(#ffffff, #1e242a);
   --float: light-dark(#ffffff, #262d35); /* tooltip, search results, controls */
   --rule: light-dark(#d6d0c4, #333b44);
   --row-line: light-dark(#e4e0d7, #2a3138);
+
+  /* The page background and the surface everthing sits on */
+  --background: light-dark(#f1eee8, #14181c);
+  --paper: light-dark(#f8f6f4, #0e1216);
+
+
   /* ---- accents ------------------------------------------------------------
      Solarized's eight. Everything coloured on the page is one of them as it
      stands, or one of them mixed by one of four amounts and nothing in between:
@@ -42,14 +46,14 @@
     color-mix(in oklab, var(--accent1-hue) 80%, white));
   --accent1-soft: light-dark(
     color-mix(in oklab, var(--accent1-hue) 20%, white),
-    color-mix(in oklab, var(--accent1-hue) 20%, var(--paper)));
+    color-mix(in oklab, var(--accent1-hue) 20%, var(--background)));
   --on-accent1: light-dark(#ffffff, #14142c); /* text on an accent1 fill */
   --accent2: light-dark(
     color-mix(in oklab, var(--accent2-hue) 80%, black),
     color-mix(in oklab, var(--accent2-hue) 80%, white));
   --accent2-soft: light-dark(
     color-mix(in oklab, var(--accent2-hue) 20%, white),
-    color-mix(in oklab, var(--accent2-hue) 20%, var(--paper)));
+    color-mix(in oklab, var(--accent2-hue) 20%, var(--background)));
   /* unresolved work — the one thing on the page that is a caveat rather than a
      fact, so it takes the palette's yellow and no other colour does */
   --warn: light-dark(
@@ -57,26 +61,19 @@
     color-mix(in oklab, var(--yellow) 80%, white));
   --warn-soft: light-dark(
     color-mix(in oklab, var(--yellow) 20%, white),
-    color-mix(in oklab, var(--yellow) 20%, var(--paper)));
+    color-mix(in oklab, var(--yellow) 20%, var(--background)));
   --grid-dot: light-dark(#cdc6b6, #2c343c);
   --scroll-thumb: light-dark(#cdc9c1, #3f4751);
   /* every row that takes part in a relationship wears this, so it is the
      quietest step on the ladder */
   --hover-row: light-dark(
     color-mix(in oklab, var(--accent1-hue) 10%, white),
-    color-mix(in oklab, var(--accent1-hue) 10%, var(--paper)));
+    color-mix(in oklab, var(--accent1-hue) 10%, var(--background)));
   --focus-ring: color-mix(in oklab, var(--accent1-hue) 20%, transparent);
   --shadow-near: light-dark(rgba(28, 36, 48, 0.06), rgba(0, 0, 0, 0.35));
   --shadow-far: light-dark(rgba(28, 36, 48, 0.25), rgba(0, 0, 0, 0.5));
   --shadow-lift: light-dark(rgba(28, 36, 48, 0.45), rgba(0, 0, 0, 0.7));
   --shadow-inset: light-dark(rgba(28, 36, 48, 0.05), rgba(0, 0, 0, 0.35));
-
-  /* A panel set into a card, halfway between the card and the page behind it. */
-  --inset: light-dark(#f8f6f4, #191e23);
-
-  /* The surfaces that hold prose: a warm step off the card, so a block of writing
-     doesn't sit on the same white as a list of data. */
-  --panel: light-dark(#f9f6f2, #191e23);
 
   /* the tables app's vocabulary, mapped onto the same palette */
   --chip: light-dark(#e9ecf2, #21262d);
@@ -115,7 +112,7 @@
 
 body {
   margin: 0;
-  background: var(--paper);
+  background: var(--background);
   color: var(--ink);
   font-family: var(--font-sans);
   font-size: var(--text-base);
@@ -153,7 +150,7 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
 .head-actions { display: flex; align-items: center; gap: 10px; }
 .icon-btn {
   flex: none; width: 38px; height: 38px; border: 1px solid var(--rule); border-radius: 9px;
-  background: var(--card); color: var(--ink); cursor: pointer;
+  background: var(--paper); color: var(--ink); cursor: pointer;
   display: inline-flex; align-items: center; justify-content: center;
 }
 /* The key badges, worn identically by a column in the diagram's tables and by

--- a/crates/data-dict-cli/render/app.css
+++ b/crates/data-dict-cli/render/app.css
@@ -7,7 +7,7 @@
 
   --ink: light-dark(#1c2430, #e3e6ea);
   --ink-soft: light-dark(#5b6675, #a3acb7);
-  --ink-faint: light-dark(#7d8794, #6f7883);
+  --ink-faint: light-dark(#66707e, #8d97a2);
   --paper: light-dark(#f1eee8, #14181c);
   --card: light-dark(#ffffff, #1e242a);
   --float: light-dark(#ffffff, #262d35); /* tooltip, search results, controls */
@@ -92,7 +92,20 @@
   --modal-shadow: light-dark(rgba(0, 0, 0, 0.32), transparent);
   --modal-glow: light-dark(transparent, rgba(255, 255, 255, 0.196));
 
-  --row-text: 11.5px; /* diagram rows and the tooltip share this size */
+  /* The two faces everything on the page wears: sans for prose, mono for
+     names, values, and micro-labels. */
+  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Type scale, in rem so the whole page follows the browser's font-size
+     setting. Pixel comments assume the 16px default. */
+  --text-sm: 0.875rem;   /* 14px — the smallest size used anywhere */
+  --text-base: 1rem;     /* 16px */
+  --text-lg: 1.125rem;   /* 18px */
+  --text-xl: 1.5rem;     /* 24px */
+  --text-2xl: 2rem;      /* 32px */
+
+  --row-text: var(--text-sm); /* diagram rows and the tooltip share this size */
 }
 
 :root[data-theme="light"] { color-scheme: only light; }
@@ -104,8 +117,8 @@ body {
   margin: 0;
   background: var(--paper);
   color: var(--ink);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  font-size: 15px;
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
   line-height: 1.55;
 }
 main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
@@ -113,7 +126,7 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
 .pagehead { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 0 0 18px; }
 /* the dataset's name and, once you are inside a table, the way back out */
 .head-title { display: flex; align-items: baseline; gap: 14px; min-width: 0; }
-h1.title { color: var(--accent1); font-size: 29px; font-weight: 700; margin: 0; }
+h1.title { color: var(--accent1); font-size: var(--text-2xl); font-weight: 700; margin: 0; }
 /* The title as a link keeps the title's own colour and weight: it should read as
    the heading it is, with the chevron the only sign it goes anywhere. Only the
    name underlines on hover, so the chevron isn't struck through. */
@@ -146,8 +159,8 @@ h1.title { color: var(--accent1); font-size: 29px; font-weight: 700; margin: 0; 
 /* The key badges, worn identically by a column in the diagram's tables and by
    the same column on its own page. */
 .key {
-  font-family: ui-sans-serif, sans-serif;
-  font-size: 9px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--accent1);
@@ -192,7 +205,7 @@ h1.title { color: var(--accent1); font-size: 29px; font-weight: 700; margin: 0; 
 /* "name: label" — the name keeps whatever (usually mono) face surrounds it;
    the label reads as plain text beside it. */
 .name-label {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-family: var(--font-sans);
   font-weight: 400;
   color: var(--ink-soft);
 }
@@ -221,7 +234,7 @@ mark { background: var(--mark); color: inherit; border-radius: 2px; padding: 0 1
 }
 #tip[hidden] { display: none; }
 #tip code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: var(--row-text);
 }
 #tip .tip-head {
@@ -248,7 +261,7 @@ mark { background: var(--mark); color: inherit; border-radius: 2px; padding: 0 1
 #tip .tip-todo .tip-head code { color: var(--warn); }
 #tip .tip-todo .prose { display: block; margin-top: 5px; color: var(--ink-soft); }
 #tip .tip-todo-note { margin-top: 9px; }
-#tip .tip-todo-lbl { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--warn); }
+#tip .tip-todo-lbl { font-family: var(--font-mono); color: var(--warn); }
 #tip .tip-todo :is(p, ul, ol) { margin: 0; }
 #tip .tip-todo :is(ul, ol) { padding-left: 1.2em; }
 #tip .tip-todo li + li { margin-top: 2px; }

--- a/crates/data-dict-cli/render/app.css
+++ b/crates/data-dict-cli/render/app.css
@@ -126,7 +126,7 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
 .pagehead { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin: 0 0 18px; }
 /* the dataset's name and, once you are inside a table, the way back out */
 .head-title { display: flex; align-items: baseline; gap: 14px; min-width: 0; }
-h1.title { color: var(--accent1); font-size: var(--text-2xl); font-weight: 700; margin: 0; }
+.pagehead h1 { color: var(--accent1); font-size: var(--text-2xl); font-weight: 700; margin: 0; }
 /* The title as a link keeps the title's own colour and weight: it should read as
    the heading it is, with the chevron the only sign it goes anywhere. Only the
    name underlines on hover, so the chevron isn't struck through. */

--- a/crates/data-dict-cli/render/app.css
+++ b/crates/data-dict-cli/render/app.css
@@ -8,14 +8,13 @@
   --ink: light-dark(#1c2430, #e3e6ea);
   --ink-soft: light-dark(#5b6675, #a3acb7);
   --ink-faint: light-dark(#66707e, #8d97a2);
-  --float: light-dark(#ffffff, #262d35); /* tooltip, search results, controls */
+  --float: light-dark(#ffffff, #161b21); /* tooltip, search results, controls */
   --rule: light-dark(#d6d0c4, #333b44);
   --row-line: light-dark(#e4e0d7, #2a3138);
 
   /* The page background and the surface everthing sits on */
-  --background: light-dark(#f1eee8, #14181c);
+  --background: light-dark(#f1eee8, #181d22);
   --paper: light-dark(#f8f6f4, #0e1216);
-
 
   /* ---- accents ------------------------------------------------------------
      Solarized's eight. Everything coloured on the page is one of them as it
@@ -87,7 +86,7 @@
   --null-fill: light-dark(#e3e3e3, #444c55);
   --null-edge: light-dark(#bcbcbc, #5a626c);
   --modal-shadow: light-dark(rgba(0, 0, 0, 0.32), transparent);
-  --modal-glow: light-dark(transparent, rgba(255, 255, 255, 0.196));
+  --modal-glow: light-dark(transparent, rgba(255, 255, 255, 0.07));
 
   /* The two faces everything on the page wears: sans for prose, mono for
      names, values, and micro-labels. */

--- a/crates/data-dict-cli/render/app.js
+++ b/crates/data-dict-cli/render/app.js
@@ -155,7 +155,7 @@ function Header({ onGlossary, atTable }) {
     <span>${name}</span>`;
   return html`<header class="pagehead">
     <div class="head-title">
-      <h1 class="title" id="dict-title">
+      <h1 id="dict-title">
         ${atTable
           ? html`<a class="homelink" href="#" title="Back to every table"
               onClick=${(e) => { e.preventDefault(); goHome(); }}>${titled(true)}</a>`
@@ -377,14 +377,14 @@ function ColumnItem({ table: t, column: c, hl, isTarget }) {
     <div class="col-main">
       <div class="col-head">
         ${c.name
-          ? html`<a class="col-name" href=${"#" + t.name + "." + c.name}
+          ? html`<h3><a class="col-name" href=${"#" + t.name + "." + c.name}
               title=${"Link to " + t.name + "." + c.name}
               onClick=${(e) => { e.preventDefault(); go("#" + t.name + "." + c.name); }}>
               <${Marked} text=${c.name} ql=${hl} />
               ${c.label && html`<span class="name-label">: ${c.label}</span>`}
               <span class="anchor-mark">#</span>
-            </a>`
-          : html`<span class="col-name">(unnamed)</span>`}
+            </a></h3>`
+          : html`<h3><span class="col-name">(unnamed)</span></h3>`}
         ${keys.map((k) =>
           k === "primary_key"
             ? html`<span class="key">PK</span>`
@@ -396,11 +396,6 @@ function ColumnItem({ table: t, column: c, hl, isTarget }) {
       ${constraints.length > 0 &&
         html`<${MetaLine} label="constraints" hl=${hl}
           items=${constraints.map((k) => k.replace(/_/g, " "))} />`}
-      ${joins.length > 0 &&
-        html`<div class="col-meta joins-line">
-          <span class="lbl">joins:</span>
-          ${joins.map((j) => html`<${JoinChip} join=${j} />`)}
-        </div>`}
       ${c.values && c.values.length > 0 &&
         (c.value_labels
           ? html`<${ValueDefs} values=${c.values} labels=${c.value_labels} hl=${hl} />`
@@ -415,6 +410,11 @@ function ColumnItem({ table: t, column: c, hl, isTarget }) {
       ${c.units != null && html`<${MetaText} label="units" text=${String(c.units)} />`}
       ${p && p.sample_values && p.sample_values.length > 0 &&
         html`<${SampleValues} values=${p.sample_values} hl=${hl} />`}
+      ${joins.length > 0 &&
+        html`<div class="col-meta joins-line">
+          <span class="lbl">joins:</span>
+          ${joins.map((j) => html`<${JoinChip} join=${j} />`)}
+        </div>`}
     </div>
     <div class="col-side">
       ${p && html`<${Histogram} profile=${p} rows=${t.rows} />`}
@@ -469,7 +469,7 @@ function TablePage({ table: t, targetCol }) {
       <div class="tpage-top">
         <div class="tpage-headmain">
           <div class="tpage-title-row">
-            <span class="mtitle"><${NameLabel} label=${t.label}><span>${t.name}</span><//></span>
+            <h2><${NameLabel} label=${t.label}><span>${t.name}</span><//></h2>
             <${TodoFlag} source=${t.todo} />
           </div>
           <div class="tpage-substat">${substat}</div>
@@ -517,7 +517,7 @@ function GlossaryModal({ onClose }) {
     <div class="modal" role="dialog" aria-modal="true" aria-labelledby="gloss-title">
       <div class="modal-head">
         <button class="modal-close" type="button" aria-label="Close" onClick=${onClose}>×</button>
-        <div class="modal-title-row"><span class="mtitle" id="gloss-title">Glossary</span></div>
+        <div class="modal-title-row"><h2 id="gloss-title">Glossary</h2></div>
         <div class="modal-substat">${glossItems.length} terms</div>
         <input class="modal-filter gloss-filter" type="search" placeholder="Filter terms…"
           autocomplete="off" ref=${filterRef} value=${filter}

--- a/crates/data-dict-cli/render/diagram.css
+++ b/crates/data-dict-cli/render/diagram.css
@@ -1,7 +1,8 @@
 /* The relationships diagram. Shares the page palette in app.css; the metrics
    and tints only the diagram uses live here. */
 :root {
-  --row-h: 30px; /* leaves ~8px above and below the text, matching --row-pad */
+  /* rem so the rows grow with the text inside them */
+  --row-h: 1.875rem; /* leaves ~8px above and below the text, matching --row-pad */
   --row-pad: 9px;
   /* mixed off the Solarized accents in app.css, towards whatever sits behind */
   --head-bg: light-dark(
@@ -95,9 +96,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  font-size: 13px;
+  font-size: var(--text-sm);
   font-weight: 600;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   letter-spacing: 0.01em;
   background: var(--head-bg);
   color: var(--head-ink);
@@ -140,7 +141,7 @@
   gap: 10px;
   height: var(--row-h);
   padding: 0 var(--row-pad);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   font-size: var(--row-text);
   white-space: nowrap;
 }
@@ -165,7 +166,7 @@
 }
 .row .name:hover { color: var(--link); text-decoration: underline; }
 .row .name:focus-visible { outline: 2px solid var(--link); outline-offset: 1px; border-radius: 2px; }
-.row .type { color: var(--ink-faint); font-size: 10.5px; }
+.row .type { color: var(--ink-soft); font-size: var(--text-sm); }
 .row .keys { display: flex; gap: 4px; }
 /* the badges themselves are styled in app.css, shared with the tables app */
 /* badges that stand for at least one relationship respond to the mouse */
@@ -251,10 +252,10 @@
 
 .node > h2 .count {
   margin-left: auto;
-  font-family: ui-sans-serif, sans-serif;
-  font-size: 10px;
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
   font-weight: 500;
-  opacity: 0.75;
+  opacity: 0.85;
 }
 
 /* ---- picking tables ------------------------------------------------------ */
@@ -327,7 +328,7 @@
 #showall {
   padding: 6px 10px;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--ink);
   background: var(--float);
   border: 1px solid var(--rule);
@@ -351,7 +352,7 @@
   width: 100%;
   padding: 6px 9px;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--text-sm);
   color: var(--ink);
   background: var(--float);
   border: 1px solid var(--rule);
@@ -374,7 +375,7 @@
   border: 1px solid var(--rule);
   border-radius: 6px;
   box-shadow: 0 10px 26px -14px var(--shadow-lift);
-  font-size: 11.5px;
+  font-size: var(--text-sm);
 }
 #hits[hidden] { display: none; }
 #hits .none { padding: 7px 9px; color: var(--ink-faint); }
@@ -384,8 +385,8 @@
   padding: 5px 9px;
   border: 0;
   background: none;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
   color: var(--ink);
   text-align: left;
   cursor: pointer;

--- a/crates/data-dict-cli/render/diagram.css
+++ b/crates/data-dict-cli/render/diagram.css
@@ -7,22 +7,22 @@
   /* mixed off the Solarized accents in app.css, towards whatever sits behind */
   --head-bg: light-dark(
     color-mix(in oklab, var(--accent1-hue) 80%, black),
-    color-mix(in oklab, var(--accent1-hue) 40%, var(--paper)));
+    color-mix(in oklab, var(--accent1-hue) 40%, var(--background)));
   --head-ink: light-dark(#ffffff, #e7f1ef);
   --demo-head: light-dark(#6b7684, #3a434d);
   --demo-rule: light-dark(#c9c4b8, #454e58);
   /* row touched by the hovered relationship */
   --tint-edge: light-dark(
     color-mix(in oklab, var(--accent1-hue) 20%, white),
-    color-mix(in oklab, var(--accent1-hue) 20%, var(--paper)));
+    color-mix(in oklab, var(--accent1-hue) 20%, var(--background)));
   /* row matching the search */
   --tint-search: light-dark(
     color-mix(in oklab, var(--mark-hue) 20%, white),
-    color-mix(in oklab, var(--mark-hue) 20%, var(--paper)));
+    color-mix(in oklab, var(--mark-hue) 20%, var(--background)));
   /* the match you selected */
   --tint-search-on: light-dark(
     color-mix(in oklab, var(--mark-hue) 40%, white),
-    color-mix(in oklab, var(--mark-hue) 40%, var(--paper)));
+    color-mix(in oklab, var(--mark-hue) 40%, var(--background)));
 }
 
 /* ---- diagram surface ---------------------------------------------------- */
@@ -41,7 +41,7 @@
 #canvas {
   height: min(87.5vh, 775px);
   overflow: auto;
-  background-color: var(--paper);
+  background-color: var(--background);
   /* faint dot grid, pinned to the board so it pans with it */
   background-image: radial-gradient(circle at 1px 1px, var(--grid-dot) 1.4px, transparent 0);
   background-size: 24px 24px;
@@ -78,7 +78,7 @@
   left: 0;
   width: max-content;
   max-width: 340px;
-  background: var(--card);
+  background: var(--paper);
   border: 1px solid var(--rule);
   border-radius: 7px;
   box-shadow: 0 1px 2px var(--shadow-near), 0 6px 16px -10px var(--shadow-far);
@@ -127,7 +127,7 @@
   right: 0;
   bottom: 0;
   height: 14px;
-  background: linear-gradient(to top, var(--card), transparent);
+  background: linear-gradient(to top, var(--paper), transparent);
   pointer-events: none;
   transition: opacity 120ms;
 }
@@ -151,7 +151,7 @@
 .row.pinned {
   position: sticky;
   z-index: 1;
-  --row-bg: var(--card);
+  --row-bg: var(--paper);
 }
 .row.pinned.linked { --row-bg: var(--hover-row); }
 .row.pin-last { box-shadow: 0 1px 0 var(--rule), 0 3px 6px -4px var(--shadow-far); }

--- a/crates/data-dict-cli/render/tables.css
+++ b/crates/data-dict-cli/render/tables.css
@@ -22,13 +22,13 @@ details.xdetails > summary:focus-visible { outline: 2px solid var(--link); outli
 .toolbar input[type=search] {
   width: 100%;
   padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--card); color: var(--ink); font-size: var(--text-sm);
+  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
 }
 
 /* ---- table index ---- */
 .tlist-wrap {
   border: 1px solid var(--rule); border-radius: 10px;
-  background: var(--card); overflow-x: auto;
+  background: var(--paper); overflow-x: auto;
 }
 .tlist { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
 .tlist thead th {
@@ -129,19 +129,14 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 }
 .tpage-substat { color: var(--ink-soft); font-size: var(--text-sm); margin: 7px 0 13px; }
 
-/* Each block of the page sits on a card over the paper: the dataset's lead, the
-   table's header, and the column list. The light palette's surfaces are close
-   together by nature, so the border is what actually separates them; the fill
-   is what stops the page reading as one flat sheet. */
+/* Each block of the page sits on a card over the background: the dataset's
+   lead, the table's header, and the column list. They all share the one
+   surface, so the border is what separates them. */
 .lead, .tpage-top, .tpage-list {
   border: 1px solid var(--rule);
   border-radius: 10px;
+  background: var(--paper);
 }
-/* The description cards take the warm panel, so prose reads as its own surface
-   without taking a colour. Opacity can't do this job: card and paper are ~20/255
-   apart, so no alpha is visible against it. */
-.lead, .tpage-top { background: var(--panel); }
-.tpage-list { background: var(--card); }
 .lead { padding: 14px 16px; margin-bottom: 20px; }
 .lead > :last-child, .lead p:last-child { margin-bottom: 0; }
 /* The rows bleed 13px outward to let a highlighted one span the full width, so
@@ -178,13 +173,13 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .tpage-controls { display: flex; gap: 10px; align-items: center; }
 .tpage-sort {
   flex: none; padding: 8px 30px 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--card) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6"><path d="M0 0l5 6 5-6z" fill="%237a7a7a"/></svg>') no-repeat right 11px center;
+  background: var(--paper) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6"><path d="M0 0l5 6 5-6z" fill="%237a7a7a"/></svg>') no-repeat right 11px center;
   color: var(--ink); font-size: var(--text-sm); cursor: pointer;
   -webkit-appearance: none; appearance: none;
 }
 .tpage-filter {
   flex: 1 1 auto; min-width: 0; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--card); color: var(--ink); font-size: var(--text-sm);
+  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
 }
 
 .col-item { padding: 11px 13px; border-bottom: 1px solid var(--rule); display: flex; gap: 22px; align-items: flex-start; margin: 0 -13px; }
@@ -197,7 +192,7 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
   padding: 16px 21px;
   border-radius: 10px;
   border: 1px solid var(--rule);
-  background: var(--card);
+  background: var(--paper);
   box-shadow: 0 1px 2px var(--shadow-near), 0 8px 22px -8px var(--shadow-far);
 }
 .col-item:has(+ .is-target) { border-bottom-color: transparent; padding-bottom: 5px }
@@ -210,7 +205,7 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 }
 .modal-overlay[hidden] { display: none; }
 .modal {
-  background: var(--card); border: 1px solid var(--rule); border-radius: 14px;
+  background: var(--paper); border: 1px solid var(--rule); border-radius: 14px;
   width: min(760px, 96vw); max-height: 86vh;
   display: flex; flex-direction: column; overflow: hidden;
   box-shadow: 0 24px 60px var(--modal-shadow), 0 0 44px var(--modal-glow);
@@ -220,7 +215,7 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .modal-substat { color: var(--ink-soft); font-size: var(--text-sm); margin: 7px 0 13px; }
 .modal-filter {
   width: 100%; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
+  background: var(--background); color: var(--ink); font-size: var(--text-sm);
 }
 .modal-close {
   position: absolute; top: 12px; right: 15px; border: none; background: transparent;
@@ -253,13 +248,13 @@ a.col-name:hover .anchor-mark, a.col-name:focus-visible .anchor-mark { opacity: 
 .col-desc { color: var(--ink); font-size: var(--text-sm); margin-top: 4px; line-height: 1.5; }
 .col-meta { color: var(--ink-soft); font-size: var(--text-sm); margin-top: 5px; }
 .col-meta .lbl { font-weight: 650; margin-right: 6px; }
-.col-meta code { font-family: var(--font-mono); background: var(--inset); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
+.col-meta code { font-family: var(--font-mono); background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
 /* One chip for every value a column reports — allowed, given as an example,
    sampled from the data, or the range and counts read off it — set off from the
    line but in the page's own text face. Join chips share the shell; what sets
    them apart is what they carry (a wire icon, mono names) and that they act. */
 .val, .join-chip {
-  background: var(--inset); border: 1px solid var(--rule); border-radius: 4px;
+  background: var(--paper); border: 1px solid var(--rule); border-radius: 4px;
   padding: 0 3px; color: var(--ink);
 }
 .val { display: inline-block; }
@@ -291,7 +286,7 @@ button.val { font: inherit; }
   margin-top: 2px;
   padding: 9px 10px 8px;
   border-radius: 6px;
-  background: var(--inset);
+  background: var(--paper);
 }
 .hist-svg { display: block; }
 .hist-svg .hist-bar { fill: var(--hist-bar); transition: fill .08s ease; shape-rendering: crispEdges;}

--- a/crates/data-dict-cli/render/tables.css
+++ b/crates/data-dict-cli/render/tables.css
@@ -236,9 +236,9 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
    left, and on the right the missing share in red, anchored left over a grey
    base — each taking half the width */
 .miss-meter { display: flex; align-items: center; gap: 8px; width: 240px; margin: 6px 10px 0; }
-.missbar { flex: 1 1 0; min-width: 0; height: 9px; border-radius: 999px; background: var(--null-fill); border: 0.5px solid var(--null-edge); box-sizing: border-box; position: relative; overflow: hidden; }
+.missbar { flex: 1 1 0; min-width: 0; height: 9px; background: var(--null-fill); border: 0.5px solid var(--null-edge); box-sizing: border-box; position: relative; overflow: hidden; }
 .missfill { position: absolute; top: -0.5px; left: -0.5px; bottom: -0.5px; min-width: 6px; border-radius: 999px 0 0 999px; background: var(--null-bar); box-sizing: border-box; }
-.missfill.full { right: -0.5px; min-width: 0; border-radius: 999px; }
+.missfill.full { right: -0.5px; min-width: 0; }
 .miss-pct { flex: 1 1 0; min-width: 0; color: var(--ink-soft); font-size: var(--text-sm); font-family: var(--font-mono); white-space: nowrap; }
 .col-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 /* the heading is the document outline; the anchor inside carries the look */

--- a/crates/data-dict-cli/render/tables.css
+++ b/crates/data-dict-cli/render/tables.css
@@ -237,8 +237,8 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .miss-pct { flex: 1 1 0; min-width: 0; color: var(--ink-soft); font-size: var(--text-sm); font-family: var(--font-mono); white-space: nowrap; }
 .col-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 /* the heading is the document outline; the anchor inside carries the look */
-.col-head h3 { margin: 0; font-size: inherit; font-weight: inherit; }
-.col-name { font-family: var(--font-mono); font-weight: 650; font-size: var(--text-sm); color: var(--ink); }
+.col-head h3 { margin: 0; font-size: inherit; font-weight: inherit; font-size: var(--text-base); }
+.col-name { font-family: var(--font-mono); font-weight: 650; color: var(--ink); }
 a.col-name { text-decoration: none; border-radius: 3px; }
 a.col-name:hover { color: var(--link); }
 a.col-name:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }

--- a/crates/data-dict-cli/render/tables.css
+++ b/crates/data-dict-cli/render/tables.css
@@ -96,10 +96,6 @@ a.cpath:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
 .tlist tbody.tgroup:not(.expanded) tr.crow.xtra { display: none; }
 
 /* rendered Markdown in prose */
-.prose code {
-  font-family: var(--font-mono); font-size: .92em;
-  background: var(--chip); border-radius: 3px; padding: 0 3px;
-}
 .prose a { color: var(--link); text-underline-offset: 2px; }
 .prose a:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; border-radius: 3px; }
 .prose p { margin: 0 0 10px; }
@@ -128,7 +124,9 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 /* ---- table detail page ---- */
 .tpage-head { padding-bottom: 14px; }
 .tpage-title-row { display: flex; align-items: center; gap: 10px; }
-.mtitle { font-family: var(--font-mono); font-weight: 650; font-size: var(--text-lg); color: var(--ink); }
+.tpage-title-row > h2, .modal-title-row > h2 {
+  font-family: var(--font-mono); font-weight: 650; font-size: var(--text-lg); color: var(--ink); margin: 0;
+}
 .tpage-substat { color: var(--ink-soft); font-size: var(--text-sm); margin: 7px 0 13px; }
 
 /* Each block of the page sits on a card over the paper: the dataset's lead, the
@@ -243,6 +241,8 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .missfill.full { right: -0.5px; min-width: 0; border-radius: 999px; }
 .miss-pct { flex: 1 1 0; min-width: 0; color: var(--ink-soft); font-size: var(--text-sm); font-family: var(--font-mono); white-space: nowrap; }
 .col-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+/* the heading is the document outline; the anchor inside carries the look */
+.col-head h3 { margin: 0; font-size: inherit; font-weight: inherit; }
 .col-name { font-family: var(--font-mono); font-weight: 650; font-size: var(--text-sm); color: var(--ink); }
 a.col-name { text-decoration: none; border-radius: 3px; }
 a.col-name:hover { color: var(--link); }
@@ -253,15 +253,16 @@ a.col-name:hover .anchor-mark, a.col-name:focus-visible .anchor-mark { opacity: 
 .col-desc { color: var(--ink); font-size: var(--text-sm); margin-top: 4px; line-height: 1.5; }
 .col-meta { color: var(--ink-soft); font-size: var(--text-sm); margin-top: 5px; }
 .col-meta .lbl { font-weight: 650; margin-right: 6px; }
-.col-meta code { font-family: var(--font-mono); background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
+.col-meta code { font-family: var(--font-mono); background: var(--inset); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
 /* One chip for every value a column reports — allowed, given as an example,
    sampled from the data, or the range and counts read off it — set off from the
-   line but in the page's own text face. */
-.val {
-  display: inline-block;
+   line but in the page's own text face. Join chips share the shell; what sets
+   them apart is what they carry (a wire icon, mono names) and that they act. */
+.val, .join-chip {
   background: var(--inset); border: 1px solid var(--rule); border-radius: 4px;
   padding: 0 3px; color: var(--ink);
 }
+.val { display: inline-block; }
 /* a chip cut short for its length: click reveals the whole value, wrapped */
 button.val { font: inherit; }
 .val.cut { cursor: pointer; }
@@ -282,7 +283,7 @@ button.val { font: inherit; }
 .more-less:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; border-radius: 3px; }
 .joins-line { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; }
 .joins-line .lbl { margin-right: 0; }
-.join-chip { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 1px 6px; color: var(--ink); cursor: pointer; transition: border-color .1s ease, color .1s ease; }
+.join-chip { display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); cursor: pointer; transition: border-color .1s ease, color .1s ease; }
 .join-chip:hover { border-color: var(--link); color: var(--link); }
 .join-chip svg { width: 20px; height: 10px; display: block; color: var(--ink-soft); }
 /* a quiet panel behind the bars, so the histogram reads as one thing */

--- a/crates/data-dict-cli/render/tables.css
+++ b/crates/data-dict-cli/render/tables.css
@@ -5,24 +5,24 @@
 details.xdetails { margin: 0 0 18px; }
 details.xdetails > summary {
   display: inline-flex; align-items: center; gap: 6px; cursor: pointer; list-style: none;
-  font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 10px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm); font-weight: 700; letter-spacing: .07em; text-transform: uppercase;
   color: var(--ink-soft);
 }
 details.xdetails > summary::-webkit-details-marker { display: none; }
-details.xdetails > summary::before { content: '\25B8'; font-size: 8px; }
+details.xdetails > summary::before { content: '\25B8'; font-size: var(--text-sm); }
 details.xdetails[open] > summary::before { content: '\25BE'; }
 details.xdetails > summary:hover { color: var(--ink); }
 details.xdetails > summary:focus-visible { outline: 2px solid var(--link); outline-offset: 3px; border-radius: 3px; }
 .xdetails-body { margin-top: 8px; max-width: 1000px; line-height: 1.55; color: var(--ink); }
 .tpage-details details.xdetails { margin: 0 0 13px; }
-.tpage-details .xdetails-body { font-size: 13.5px; max-width: none; }
+.tpage-details .xdetails-body { font-size: var(--text-sm); max-width: none; }
 
 .toolbar { margin-bottom: 14px; }
 .toolbar input[type=search] {
   width: 100%;
   padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--card); color: var(--ink); font-size: 14px;
+  background: var(--card); color: var(--ink); font-size: var(--text-sm);
 }
 
 /* ---- table index ---- */
@@ -30,11 +30,11 @@ details.xdetails > summary:focus-visible { outline: 2px solid var(--link); outli
   border: 1px solid var(--rule); border-radius: 10px;
   background: var(--card); overflow-x: auto;
 }
-.tlist { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tlist { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
 .tlist thead th {
   text-align: left; padding: 8px 14px; white-space: nowrap;
-  font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm); font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
   color: var(--ink-soft); border-bottom: 1px solid var(--rule);
 }
 .tlist th.num, .tlist td.num { text-align: right; font-variant-numeric: tabular-nums; }
@@ -50,14 +50,14 @@ details.xdetails > summary:focus-visible { outline: 2px solid var(--link); outli
 .tlist tbody.tgroup:not(:has(.drow)) tr.trow td { padding-bottom: 10px; }
 
 a.tname {
-  font-family: ui-monospace, Menlo, Consolas, monospace; font-weight: 650; font-size: 13px;
+  font-family: var(--font-mono); font-weight: 650; font-size: var(--text-sm);
   color: var(--ink); text-decoration: none; border-radius: 3px;
 }
 a.tname:hover { color: var(--link); }
 a.tname:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
-.tlist td.size { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 11.5px; color: var(--ink-soft); white-space: nowrap; }
+.tlist td.size { font-family: var(--font-mono); font-size: var(--text-sm); color: var(--ink-soft); white-space: nowrap; }
 .tlist .stimes { margin: 0 5px; opacity: .55; }
-.tlist td.desc { color: var(--ink); font-size: 12.5px; line-height: 1.45; }
+.tlist td.desc { color: var(--ink); font-size: var(--text-sm); line-height: 1.45; }
 /* the clamp needs a block of its own; a <td> does not honour -webkit-box */
 .tlist td.desc .dclamp {
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
@@ -66,11 +66,11 @@ a.tname:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
 /* the search's receipt: the columns that matched, nested under their table */
 .tlist tr.mhead td.mheadcell { padding-top: 5px; padding-bottom: 3px; }
 .mlbl {
-  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 10px; font-weight: 700;
+  font-family: var(--font-mono); font-size: var(--text-sm); font-weight: 700;
   letter-spacing: .06em; text-transform: uppercase; color: var(--ink-soft);
 }
 button.showall {
-  font: inherit; font-size: 11px; margin-left: 10px; padding: 0;
+  font: inherit; font-size: var(--text-sm); margin-left: 10px; padding: 0;
   border: none; background: none; color: var(--link); cursor: pointer; text-decoration: underline;
 }
 button.showall:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
@@ -79,7 +79,7 @@ button.showall:focus-visible { outline: 2px solid var(--link); outline-offset: 2
 .tlist tbody.tgroup tr.crow:last-child td { padding-bottom: 10px; }
 .tlist td.csub { padding-left: 26px; white-space: nowrap; }
 a.cpath {
-  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 12px;
+  font-family: var(--font-mono); font-size: var(--text-sm);
   text-decoration: none; border-radius: 3px;
 }
 a.cpath .cp-tbl { color: var(--ink-soft); }
@@ -88,16 +88,16 @@ a.cpath:hover .cp-col, a.cpath:hover .cp-tbl { color: var(--link); }
 a.cpath:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
 .cwhere {
   margin-left: 8px;
-  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 9.5px;
+  font-family: var(--font-mono); font-size: var(--text-sm);
   letter-spacing: .04em; text-transform: uppercase; color: var(--ink-soft);
 }
-.tlist td.csub-desc { font-size: 12px; color: var(--ink-soft); line-height: 1.4; text-align: left; }
+.tlist td.csub-desc { font-size: var(--text-sm); color: var(--ink-soft); line-height: 1.4; text-align: left; }
 .dclamp1 { display: -webkit-box; -webkit-line-clamp: 1; -webkit-box-orient: vertical; overflow: hidden; }
 .tlist tbody.tgroup:not(.expanded) tr.crow.xtra { display: none; }
 
 /* rendered Markdown in prose */
 .prose code {
-  font-family: ui-monospace, Menlo, Consolas, monospace; font-size: .92em;
+  font-family: var(--font-mono); font-size: .92em;
   background: var(--chip); border-radius: 3px; padding: 0 3px;
 }
 .prose a { color: var(--link); text-underline-offset: 2px; }
@@ -115,7 +115,7 @@ abbr.gterm {
 }
 abbr.gterm:hover { text-decoration-color: var(--accent1); }
 
-.tables-empty { color: var(--ink-soft); font-size: 13.5px; padding: 18px 14px; }
+.tables-empty { color: var(--ink-soft); font-size: var(--text-sm); padding: 18px 14px; }
 
 @media (max-width: 720px) {
   .tlist td.csub-desc { display: none; }
@@ -128,8 +128,8 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 /* ---- table detail page ---- */
 .tpage-head { padding-bottom: 14px; }
 .tpage-title-row { display: flex; align-items: center; gap: 10px; }
-.mtitle { font-family: ui-monospace, Menlo, Consolas, monospace; font-weight: 650; font-size: 18px; color: var(--ink); }
-.tpage-substat { color: var(--ink-soft); font-size: 12.5px; margin: 7px 0 13px; }
+.mtitle { font-family: var(--font-mono); font-weight: 650; font-size: var(--text-lg); color: var(--ink); }
+.tpage-substat { color: var(--ink-soft); font-size: var(--text-sm); margin: 7px 0 13px; }
 
 /* Each block of the page sits on a card over the paper: the dataset's lead, the
    table's header, and the column list. The light palette's surfaces are close
@@ -159,7 +159,7 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .tpage-headmain { flex: 1 1 auto; min-width: 0; }
 .tpage-headmain > :last-child, .tpage-main > :last-child { margin-bottom: 0; }
 .tpage-main { max-width: 76ch; }
-.tpage-desc { color: var(--ink); font-size: 13.5px; margin: 0 0 13px; }
+.tpage-desc { color: var(--ink); font-size: var(--text-sm); margin: 0 0 13px; }
 .tpage-desc:last-child { margin-bottom: 0; }
 /* Outlined rather than filled — it is already on the card, so a border is all
    it takes to set it apart. Sized by its chips, so a table with a few relations
@@ -171,8 +171,8 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 }
 .tpage-related[hidden] { display: none; }
 .tpage-related .rel-lbl {
-  font-family: ui-monospace, Menlo, Consolas, monospace;
-  font-size: 10px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm); font-weight: 700; letter-spacing: .07em; text-transform: uppercase;
   color: var(--ink-soft); margin-bottom: 8px;
 }
 .tpage-related .rel-chips { display: flex; flex-wrap: wrap; gap: 6px; }
@@ -181,12 +181,12 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .tpage-sort {
   flex: none; padding: 8px 30px 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
   background: var(--card) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6"><path d="M0 0l5 6 5-6z" fill="%237a7a7a"/></svg>') no-repeat right 11px center;
-  color: var(--ink); font-size: 13.5px; cursor: pointer;
+  color: var(--ink); font-size: var(--text-sm); cursor: pointer;
   -webkit-appearance: none; appearance: none;
 }
 .tpage-filter {
   flex: 1 1 auto; min-width: 0; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--card); color: var(--ink); font-size: 14px;
+  background: var(--card); color: var(--ink); font-size: var(--text-sm);
 }
 
 .col-item { padding: 11px 13px; border-bottom: 1px solid var(--rule); display: flex; gap: 22px; align-items: flex-start; margin: 0 -13px; }
@@ -219,14 +219,14 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 }
 .modal-head { flex: none; padding: 18px 22px 14px; border-bottom: 1px solid var(--rule); position: relative; }
 .modal-title-row { display: flex; align-items: center; gap: 10px; }
-.modal-substat { color: var(--ink-soft); font-size: 12.5px; margin: 7px 0 13px; }
+.modal-substat { color: var(--ink-soft); font-size: var(--text-sm); margin: 7px 0 13px; }
 .modal-filter {
   width: 100%; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--paper); color: var(--ink); font-size: 14px;
+  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
 }
 .modal-close {
   position: absolute; top: 12px; right: 15px; border: none; background: transparent;
-  font-size: 24px; line-height: 1; color: var(--ink-soft); cursor: pointer;
+  font-size: var(--text-xl); line-height: 1; color: var(--ink-soft); cursor: pointer;
 }
 .modal-close:hover { color: var(--ink); }
 .modal-body { flex: 1; overflow-y: auto; padding: 4px 22px 22px; }
@@ -241,19 +241,19 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .missbar { flex: 1 1 0; min-width: 0; height: 9px; border-radius: 999px; background: var(--null-fill); border: 0.5px solid var(--null-edge); box-sizing: border-box; position: relative; overflow: hidden; }
 .missfill { position: absolute; top: -0.5px; left: -0.5px; bottom: -0.5px; min-width: 6px; border-radius: 999px 0 0 999px; background: var(--null-bar); box-sizing: border-box; }
 .missfill.full { right: -0.5px; min-width: 0; border-radius: 999px; }
-.miss-pct { flex: 1 1 0; min-width: 0; color: var(--ink-soft); font-size: 11px; font-family: ui-monospace, Menlo, Consolas, monospace; white-space: nowrap; }
+.miss-pct { flex: 1 1 0; min-width: 0; color: var(--ink-soft); font-size: var(--text-sm); font-family: var(--font-mono); white-space: nowrap; }
 .col-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.col-name { font-family: ui-monospace, Menlo, Consolas, monospace; font-weight: 650; font-size: 13.5px; color: var(--ink); }
+.col-name { font-family: var(--font-mono); font-weight: 650; font-size: var(--text-sm); color: var(--ink); }
 a.col-name { text-decoration: none; border-radius: 3px; }
 a.col-name:hover { color: var(--link); }
 a.col-name:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
 /* the anchor mark holds its space, so hovering never nudges the row */
 a.col-name .anchor-mark { margin-left: 6px; font-weight: 400; color: var(--ink-soft); opacity: 0; }
 a.col-name:hover .anchor-mark, a.col-name:focus-visible .anchor-mark { opacity: 1; }
-.col-desc { color: var(--ink); font-size: 13px; margin-top: 4px; line-height: 1.5; }
-.col-meta { color: var(--ink-soft); font-size: 11.5px; margin-top: 5px; }
+.col-desc { color: var(--ink); font-size: var(--text-sm); margin-top: 4px; line-height: 1.5; }
+.col-meta { color: var(--ink-soft); font-size: var(--text-sm); margin-top: 5px; }
 .col-meta .lbl { font-weight: 650; margin-right: 6px; }
-.col-meta code { font-family: ui-monospace, Menlo, Consolas, monospace; background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
+.col-meta code { font-family: var(--font-mono); background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
 /* One chip for every value a column reports — allowed, given as an example,
    sampled from the data, or the range and counts read off it — set off from the
    line but in the page's own text face. */
@@ -282,7 +282,7 @@ button.val { font: inherit; }
 .more-less:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; border-radius: 3px; }
 .joins-line { display: flex; align-items: center; flex-wrap: wrap; gap: 6px; }
 .joins-line .lbl { margin-right: 0; }
-.join-chip { display: inline-flex; align-items: center; gap: 6px; font-family: ui-monospace, Menlo, Consolas, monospace; background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 1px 6px; color: var(--ink); cursor: pointer; transition: border-color .1s ease, color .1s ease; }
+.join-chip { display: inline-flex; align-items: center; gap: 6px; font-family: var(--font-mono); background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 1px 6px; color: var(--ink); cursor: pointer; transition: border-color .1s ease, color .1s ease; }
 .join-chip:hover { border-color: var(--link); color: var(--link); }
 .join-chip svg { width: 20px; height: 10px; display: block; color: var(--ink-soft); }
 /* a quiet panel behind the bars, so the histogram reads as one thing */
@@ -302,15 +302,15 @@ button.val { font: inherit; }
 .hist-svg .hist-band { fill: transparent; transition: fill .08s ease; }
 .hist-svg .hist-band.hot { fill: var(--hist-band); }
 .hist-svg .hist-hit { fill: transparent; }
-.hist-cap { color: var(--ink-soft); font-size: 11px; margin-top: 4px; font-family: ui-monospace, Menlo, Consolas, monospace; }
+.hist-cap { color: var(--ink-soft); font-size: var(--text-sm); margin-top: 4px; font-family: var(--font-mono); }
 /* the observed extremes as axis labels: min under the left edge, max under
    the right */
 .hist-cap-range { display: flex; justify-content: space-between; gap: 8px; }
 .hist-cap-range .cap-mid { color: var(--ink-faint); }
 .gloss-item { padding: 12px 0; border-bottom: 1px solid var(--rule); }
 .gloss-item:last-child { border-bottom: none; }
-.gloss-term { font-weight: 700; font-size: 14.5px; color: var(--ink); }
-.gloss-def { color: var(--ink); font-size: 13px; margin-top: 3px; line-height: 1.55; }
+.gloss-term { font-weight: 700; font-size: var(--text-base); color: var(--ink); }
+.gloss-def { color: var(--ink); font-size: var(--text-sm); margin-top: 3px; line-height: 1.55; }
 
 /* On a narrow window the profiles and the related-tables box come off the
    right-hand side and sit under what they sat beside. Last, so it outranks the


### PR DESCRIPTION
Closes #197. Closes #201.

## Readability
- Raise `--ink-faint` contrast to WCAG AA in both light and dark mode; every text/surface pair now passes AA 
- Convert all font sizes to a five-step rem scale (`--text-sm` through `--text-2xl`) with a 14px floor, so the pages honor the browser's font-size setting, and there's no longer tiny text.
- Centralise the font stacks into `--font-sans` and `--font-mono`, unifying the two mono stacks that had drifted apart

## Accessibility
- Table names are now `h2`, column names `h3`, and the glossary modal title is a real `h2`, giving each page a proper heading outline; headings are styled by scoped element selectors rather than classes

## Surfaces and chips
- Flatten the surface palette to two variables: `--background` (the page) and `--paper` (every surface on it), replacing `--card`, `--inset`, and `--panel`
- Value chips, join chips, and code chips share one style on `--paper` with a hairline border, so they no longer compete for attention (#201)
- Dark-mode tune-ups: paper steps darker than the background (consistent with light mode's direction), the background is a skosh lighter (`#181d22`), the glossary modal halo is a third of its former opacity, and the tooltip/search/controls surface (`--float`) is darkened to match

## Misc

- Move the joins line to the bottom of a column's metadata
