### PR TITLE
Minimal mode: SGD stress layout with constraint-graph straightening

### DIFF
--- a/crates/data-dict-cli/render/app.js
+++ b/crates/data-dict-cli/render/app.js
@@ -199,6 +199,8 @@ function RelationshipsDiagram() {
           <button id="showall" type="button" hidden
             title="Put every table back on the board">show all</button>
           <button id="tidy" type="button" disabled title="Lay the tables out again">tidy</button>
+          <button id="minimal" type="button" aria-pressed="false"
+            title="Show each table as its name only">minimal</button>
           <div id="diagram-search">
             <input id="find" type="search" placeholder="Find a column…"
               autocomplete="off" spellcheck="false" aria-label="Find a column" />

--- a/crates/data-dict-cli/render/diagram.css
+++ b/crates/data-dict-cli/render/diagram.css
@@ -324,7 +324,18 @@
 
 #diagram-search { width: 232px; }
 
+/* Minimal mode: a table is its heading only, and one wire carries each
+   relationship, so the column rows and their scroll fades come off the box. */
+#canvas.minimal .node .rows { display: none; }
+#canvas.minimal .node::after { display: none; }
+/* The size moves to a second line, keeping the name line short so the boxes —
+   and the gaps the wires cross — stay small. */
+#canvas.minimal .node > h2 { flex-wrap: wrap; row-gap: 0; }
+#canvas.minimal .node > h2 .count { flex-basis: 100%; margin-left: 0; order: 3; }
+#canvas.minimal .node > h2 .eye { order: 2; margin-left: auto; }
+
 #tidy,
+#minimal,
 #showall {
   padding: 6px 10px;
   font: inherit;
@@ -338,7 +349,9 @@
   white-space: nowrap;
 }
 #tidy:hover,
+#minimal:hover,
 #showall:hover { border-color: var(--accent1); }
+#minimal[aria-pressed="true"] { color: var(--accent1); border-color: var(--accent1-soft); }
 /* nothing has been dragged, so there is nothing to tidy */
 #tidy[disabled] { opacity: 0.45; cursor: default; }
 #tidy[disabled]:hover { border-color: var(--rule); }

--- a/crates/data-dict-cli/render/diagram.js
+++ b/crates/data-dict-cli/render/diagram.js
@@ -33,6 +33,11 @@ window.DIAGRAM_INIT = () => {
 
 const MAX_ROWS_H = 300; // fixed maximum height of a table's scroll area
 
+// Minimal mode: tables are names only, each relationship is one wire anchored
+// to the box centres, and the layout skips its row-aware ordering pass (its
+// whole job is ordering tables for wires that land on rows).
+let minimal = false;
+
 const canvas = document.getElementById("canvas");
 const stage = document.getElementById("stage");
 const wires = document.getElementById("wires");
@@ -302,6 +307,55 @@ const SIDE_PAIRS = [
   [1, 1], // both right, for boxes level with or overlapping each other
   [0, 0], // both left
 ];
+
+// Minimal mode anchors a wire to the 3×3 grid of compass points on each box
+// — corners and edge midpoints — and picks the pair with the shortest
+// distance between them. Aligned boxes get facing edge midpoints (a straight
+// horizontal or vertical wire), offset boxes get facing corners, with no
+// angle threshold to tune. The curve's handles leave along each anchor's
+// outward direction, so a vertical wire doesn't bend sideways the way a
+// left/right-anchored one would.
+const COMPASS = [
+  [1, 0.5], [1, 1], [0.5, 1], [0, 1],
+  [0, 0.5], [0, 0], [0.5, 0], [1, 0],
+];
+function compassPair(from, to) {
+  let best = null;
+  for (const [fx, fy] of COMPASS) {
+    for (const [gx, gy] of COMPASS) {
+      const a = {
+        x: from.x + fx * from.width,
+        y: from.y + fy * from.height,
+        dx: fx * 2 - 1,
+        dy: fy * 2 - 1,
+      };
+      const b = {
+        x: to.x + gx * to.width,
+        y: to.y + gy * to.height,
+        dx: gx * 2 - 1,
+        dy: gy * 2 - 1,
+      };
+      const d = Math.hypot(b.x - a.x, b.y - a.y);
+      if (!best || d < best.d) best = { a, b, d };
+    }
+  }
+  return best;
+}
+
+// The wire between the nearest anchor pair is nearly straight: each anchor
+// is a point of its box nearest the other box, so the segment can't clip
+// either box. Short handles along the anchors' outward directions take the
+// edge off without the S-bend that long handles gave mismatched anchors.
+function compassWire(from, to) {
+  const { a, b, d } = compassPair(from, to);
+  const k = Math.min(d * 0.08, 18);
+  return {
+    points: [a, b],
+    d:
+      `M${a.x},${a.y} ` +
+      `C${a.x + k * a.dx},${a.y + k * a.dy} ${b.x + k * b.dx},${b.y + k * b.dy} ${b.x},${b.y}`,
+  };
+}
 
 function bestWire(from, to, fromY, toY, nodes, ends) {
   const boxes = Object.entries(nodes)
@@ -1037,9 +1091,13 @@ function writeLayout(record) {
   } catch {}
 }
 
+// Tidying discards the arrangement but not the mode: minimal/regular is a
+// viewing choice, not part of how the tables were arranged.
 function forgetLayout() {
   try {
+    const { minimal } = readLayout() ?? {};
     localStorage.removeItem(LAYOUT_KEY);
+    if (minimal !== undefined) writeLayout({ minimal });
   } catch {}
 }
 
@@ -1189,8 +1247,10 @@ async function draw(was = null) {
     markerLayer.appendChild(markerGroup);
 
     // A join on more than one column is one relationship drawn as several
-    // parallel wires, hovered and highlighted together.
-    const strands = columnPairs(edge.rel).map((pair) => {
+    // parallel wires, hovered and highlighted together. Minimal mode draws a
+    // single wire for the relationship instead.
+    const pairs = columnPairs(edge.rel);
+    const strands = (minimal ? pairs.slice(0, 1) : pairs).map((pair) => {
       const hit = make("path", { class: "hit" }); // fat transparent path, easier to hover
       const path = make("path", { class: "wire" });
       wireGroup.append(hit, path);
@@ -1263,17 +1323,23 @@ async function draw(was = null) {
         // anywhere relative to its partner.
         const fromAt = layout.nodes[pair.from.table];
         const toAt = layout.nodes[pair.to.table];
-        const points = bestWire(
-          fromAt,
-          toAt,
-          fromAt.y + anchorY(fromBox, pair.from.column),
-          toAt.y + anchorY(toBox, pair.to.column),
-          layout.nodes,
-          [pair.from.table, pair.to.table]
-        );
+        // A self-join has no direction to face, so it keeps the router's
+        // doubling-back loop.
+        const direct = minimal && pair.from.table !== pair.to.table;
+        const compass = direct ? compassWire(fromAt, toAt) : null;
+        const points = direct
+          ? compass.points
+          : bestWire(
+              fromAt,
+              toAt,
+              minimal ? fromAt.y + fromAt.height / 2 : fromAt.y + anchorY(fromBox, pair.from.column),
+              minimal ? toAt.y + toAt.height / 2 : toAt.y + anchorY(toBox, pair.to.column),
+              layout.nodes,
+              [pair.from.table, pair.to.table]
+            );
         strand.final = points;
 
-        const route = wirePath(points);
+        const route = direct ? compass.d : wirePath(points);
         path.setAttribute("d", route);
         hit.setAttribute("d", route);
 
@@ -1345,6 +1411,23 @@ function countCrossings(drawn) {
 // Tidy only offers itself once a table has been dragged, or once a saved
 // arrangement has been put back: until then the layout is already tidy. Tidying
 // discards the saved arrangement, so it doesn't return on the next visit.
+const minimalBtn = document.getElementById("minimal");
+const setMinimal = (on) => {
+  minimal = on;
+  window.MINIMAL = on; // the layout script reads this
+  canvas.classList.toggle("minimal", on);
+  minimalBtn.setAttribute("aria-pressed", String(on));
+};
+minimalBtn.addEventListener("click", () => {
+  setMinimal(!minimal);
+  writeLayout({ ...readLayout(), minimal });
+  draw(placed?.nodes);
+});
+// The mode is part of the saved layout record, so a reload comes back the
+// way the board was left. Applied before the first draw, which then lays out
+// for the restored mode straight away.
+setMinimal(!!readLayout()?.minimal);
+
 const tidyBtn = document.getElementById("tidy");
 tidyBtn.addEventListener("click", () => {
   for (const box of nodeEls.values()) box.style.zIndex = "";

--- a/crates/data-dict-cli/render/layout-dagre.js
+++ b/crates/data-dict-cli/render/layout-dagre.js
@@ -16,6 +16,10 @@ const NODE_SEP = 40;
 const RANK_SEP = 76; // wires only have to carry a small marker, not a text label
 const LABEL_W = 24;
 const LABEL_H = 18;
+// The minimum gap between boxes, shared by the constraint solve, the
+// hill-climb's overlap test, and the separation pass so the three don't
+// re-move pairs another one just placed.
+const BOX_GAP = 12;
 
 window.LAYOUT = function layoutWithDagre(dict, metrics, space = 0, was = null) {
   // Which two tables a relationship runs between. The renderer works this out the
@@ -43,7 +47,9 @@ window.LAYOUT = function layoutWithDagre(dict, metrics, space = 0, was = null) {
   const edges = links.map((rel) => ({ rel }));
   let rows = { moved: [] };
 
-  if (attached.length) {
+  if (attached.length && window.MINIMAL) {
+    stressPlace(attached, links, metrics, nodes, was);
+  } else if (attached.length) {
     const g = new dagre.graphlib.Graph({ multigraph: true });
     g.setGraph({ rankdir: "LR", nodesep: NODE_SEP, ranksep: RANK_SEP, marginx: MARGIN, marginy: MARGIN });
     g.setDefaultEdgeLabel(() => ({}));
@@ -73,7 +79,9 @@ window.LAYOUT = function layoutWithDagre(dict, metrics, space = 0, was = null) {
     // dagre's own waypoints are dropped: the renderer routes each wire from the
     // final box positions, since these get left-aligned, reordered and slid about
     // after dagre has had its say.
-    rows = orderByRow(metrics, nodes, edges, was);
+    // Minimal mode anchors wires to box centres, so dagre's node-granularity
+    // ordering is already the right one and the row-aware pass is skipped.
+    rows = window.MINIMAL ? { moved: [] } : orderByRow(metrics, nodes, edges, was);
     normalize(nodes);
   }
 
@@ -92,16 +100,18 @@ window.LAYOUT = function layoutWithDagre(dict, metrics, space = 0, was = null) {
   height = Math.max(height, grid.height);
 
   const notes = [
-    rows.moved.length
-      ? `row ordering moved ${rows.moved.join(" and ")}`
-      : "row ordering left dagre's order alone",
+    window.MINIMAL
+      ? "stress layout (SGD)"
+      : rows.moved.length
+        ? `row ordering moved ${rows.moved.join(" and ")}`
+        : "row ordering left dagre's order alone",
   ];
   if (loose.length) notes.push(`${loose.length} unattached below`);
   const off = dict.tables.length - shown.length;
   if (off) notes.unshift(`${off} of ${dict.tables.length} tables off the board`);
 
   return {
-    engine: `dagre ${dagre.version ?? "3.1.0"}`,
+    engine: window.MINIMAL ? "stress (SGD, Zheng et al. 2019)" : `dagre ${dagre.version ?? "3.1.0"}`,
     width,
     height,
     nodes,
@@ -109,6 +119,446 @@ window.LAYOUT = function layoutWithDagre(dict, metrics, space = 0, was = null) {
     note: notes.join(" · "),
   };
 };
+
+// Small seeded PRNG so the SGD shuffles — and so the whole layout — are
+// deterministic.
+function mulberry32(seed) {
+  let a = seed | 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// Non-directed layout for minimal mode: a full stress model solved by
+// stochastic gradient descent (Zheng, Pawar & Goodman, "Graph Drawing by
+// Stochastic Gradient Descent", IEEE TVCG 2019, arXiv:1710.04626). Every pair
+// of tables contributes a term pulling the distance between them towards an
+// ideal, weighted 1/d² — so a star's hub lands in the middle by construction,
+// which a layered layout can't do and local springs only manage by luck.
+//
+// Where the solver settles still depends on where it starts, so the layout
+// runs from several deterministic starts — the previous layout, then
+// golden-angle spirals — and keeps the one with the fewest wire crossings.
+function stressPlace(attached, links, metrics, nodes, was) {
+  const RESTARTS = 8;
+  const EPOCHS = 200;
+  const K = 180; // ideal length of a wire between directly joined tables
+  const GRID = 40; // hill-climb step size
+
+  const ids = attached.map((table) => table.name).sort();
+
+  // Parallel relationships between the same two tables collapse to one spring:
+  // a second spring pulls the same way and buys the layout nothing.
+  const seen = new Set();
+  const springs = [];
+  for (const rel of links) {
+    const ends = window.REL_ENDS(rel);
+    const key = [...ends].sort().join("\0");
+    if (seen.has(key)) continue;
+    seen.add(key);
+    springs.push(ends);
+  }
+
+  // All-pairs shortest paths by BFS (the graph is unweighted), becoming the
+  // stress terms. The ideal distance is K per hop, inflated by the two boxes'
+  // half-extents (Gansner & Hu, arXiv:0911.0626) so the stress model itself
+  // keeps boxes apart rather than leaving it all to the separation pass;
+  // that pass stays as the hard guarantee. Pairs in separate components get
+  // no term.
+  const adj = new Map(ids.map((id) => [id, []]));
+  for (const [u, v] of springs) {
+    adj.get(u).push(v);
+    adj.get(v).push(u);
+  }
+  const extent = (id) => {
+    const m = metrics.get(id);
+    return (m.width + m.height) / 4; // mean of the two axes' half-extents
+  };
+  const terms = [];
+  for (let i = 0; i < ids.length; i++) {
+    const dist = new Map([[ids[i], 0]]);
+    const queue = [ids[i]];
+    while (queue.length) {
+      const u = queue.shift();
+      for (const v of adj.get(u)) {
+        if (!dist.has(v)) {
+          dist.set(v, dist.get(u) + 1);
+          queue.push(v);
+        }
+      }
+    }
+    for (let j = i + 1; j < ids.length; j++) {
+      const hops = dist.get(ids[j]);
+      if (hops === undefined) continue;
+      const d = K * hops + extent(ids[i]) + extent(ids[j]);
+      terms.push({ a: ids[i], b: ids[j], d, w: 1 / (d * d) });
+    }
+  }
+
+  // The s_gd2 annealing schedule: step sizes decay exponentially from
+  // 1/min(w) to 0.1/max(w) over the epochs.
+  const wMin = Math.min(...terms.map((t) => t.w));
+  const wMax = Math.max(...terms.map((t) => t.w));
+  const ETA_MAX = 1 / wMin;
+  const ETA_MIN = 0.1 / wMax;
+
+  const cx = (n) => n.x + n.width / 2;
+  const cy = (n) => n.y + n.height / 2;
+
+  let best = null;
+  for (let attempt = 0; attempt < RESTARTS; attempt++) {
+    const pos = {};
+    ids.forEach((id, i) => {
+      const m = metrics.get(id);
+      const at = attempt === 0 ? was?.[id] : null;
+      const angle = i * 2.399963 + attempt * 0.7; // golden-angle spiral
+      const r = 300 + attempt * 30;
+      pos[id] = {
+        x: at ? at.x : 500 + r * Math.cos(angle),
+        y: at ? at.y : 400 + r * Math.sin(angle),
+        width: m.width,
+        height: m.height,
+      };
+    });
+
+    // One seeded PRNG per attempt keeps the term shuffles deterministic.
+    const rand = mulberry32(0x9e3779b9 + attempt);
+    for (let epoch = 0; epoch < EPOCHS && terms.length; epoch++) {
+      const eta = ETA_MAX * Math.pow(ETA_MIN / ETA_MAX, epoch / (EPOCHS - 1));
+      for (let i = terms.length - 1; i > 0; i--) {
+        const j = Math.floor(rand() * (i + 1));
+        [terms[i], terms[j]] = [terms[j], terms[i]];
+      }
+      for (const { a, b, d, w } of terms) {
+        const mu = Math.min(w * eta, 1);
+        const pa = pos[a];
+        const pb = pos[b];
+        let dx = cx(pa) - cx(pb);
+        let dy = cy(pa) - cy(pb);
+        const mag = Math.hypot(dx, dy) || 0.01;
+        const r = ((mag - d) / (2 * mag)) * mu;
+        dx *= r;
+        dy *= r;
+        pa.x -= dx;
+        pa.y -= dy;
+        pb.x += dx;
+        pb.y += dy;
+      }
+    }
+
+    // Straighten the wires and align the tables with the constraint-graph
+    // solve; separate() stays as the hard no-overlap guarantee behind it.
+    alignStraighten(springs, pos, ids);
+    separate(pos, ids);
+
+    // Then hill-climb: nudge each table one grid step in each of the 8
+    // directions, keeping whatever lowers the cost. This is the move someone
+    // makes by hand when a layout is almost right, and it gets the search
+    // out of the local minimum the springs settle into.
+    hillClimb(springs, pos, ids, GRID);
+
+    const cost = wireCost(springs, pos);
+    if (!best || cost < best.cost) best = { cost, pos };
+  }
+
+  for (const id of ids) nodes[id] = best.pos[id];
+  normalize(nodes);
+}
+
+// Straighten and align once the solver has settled. Each wire's angle is
+// rounded to a compass label; horizontal and vertical wires become equality
+// constraints between their tables' centre coordinates (a horizontal wire is
+// straight iff the two boxes share a centre y, since the E/W anchors sit at
+// centre height). Each axis is then solved as a constraint graph — equality
+// groups as nodes, non-overlap as left-of/above arcs — assigned by longest
+// path. This is TSM-style compaction, and the coordinate-assignment half of
+// Shape-Metrics (arXiv:2508.19416), reduced to what rectangle nodes need:
+// for boxes the "straight wire" condition is a soft local constraint, so no
+// SAT search is required. A wire whose constraint would stack its tables
+// keeps its diagonal — the renderer draws 45° runs happily, so the
+// degradation is graceful.
+function alignStraighten(springs, pos, ids) {
+  const centreX = (id) => pos[id].x + pos[id].width / 2;
+  const centreY = (id) => pos[id].y + pos[id].height / 2;
+  const eq = { x: [], y: [] };
+  for (const [u, v] of springs) {
+    // Same bias as the renderer's anchors: a wire up to 35° off a cardinal
+    // direction is labelled straight, so the solve pulls its tables into
+    // exact alignment and the wire draws exactly horizontal or vertical.
+    const ax = Math.abs(centreX(v) - centreX(u));
+    const ay = Math.abs(centreY(v) - centreY(u));
+    if (Math.min(ax, ay) > 0.7 * Math.max(ax, ay)) continue; // diagonal
+    if (ax > ay) eq.y.push([u, v]); // E or W: share a centre y
+    else eq.x.push([u, v]); // N or S: share a centre x
+  }
+  // Solving one axis moves boxes on the other, changing which pairs overlap
+  // there — and so the arcs — so the two axes alternate until they settle.
+  for (let round = 0; round < 6; round++) {
+    const movedY = solveAxis(pos, ids, eq.y, "y");
+    const movedX = solveAxis(pos, ids, eq.x, "x");
+    if (!movedY && !movedX) break;
+  }
+}
+
+// One axis of the constraint solve. Equality edges merge tables into groups
+// sharing a centre coordinate; a merge is refused when a separation arc
+// already runs between the two groups, since accepting it would stack the
+// boxes. Group coordinates are then longest-path assigned from the arcs.
+// Returns whether any centre moved.
+function solveAxis(pos, ids, eqEdges, axis, pad = BOX_GAP) {
+  const centre = (id) => {
+    const n = pos[id];
+    return axis === "x" ? n.x + n.width / 2 : n.y + n.height / 2;
+  };
+  const setCentre = (id, c) => {
+    const n = pos[id];
+    if (axis === "x") n.x = c - n.width / 2;
+    else n.y = c - n.height / 2;
+  };
+  const size = (id) => (axis === "x" ? pos[id].width : pos[id].height);
+  const oCentre = (id) => {
+    const n = pos[id];
+    return axis === "x" ? n.y + n.height / 2 : n.x + n.width / 2;
+  };
+  const oHalf = (id) => (axis === "x" ? pos[id].height : pos[id].width) / 2;
+
+  const parent = new Map(ids.map((id) => [id, id]));
+  const find = (id) => {
+    let root = id;
+    while (parent.get(root) !== root) root = parent.get(root);
+    while (parent.get(id) !== root) {
+      const next = parent.get(id);
+      parent.set(id, root);
+      id = next;
+    }
+    return root;
+  };
+
+  // Separation arcs between the current groups, from current positions: two
+  // groups whose intervals on the other axis overlap must keep their order on
+  // this one, with a centre gap that clears their widest member pair.
+  const buildArcs = () => {
+    const groups = new Map();
+    for (const id of ids) {
+      const g = find(id);
+      if (!groups.has(g)) groups.set(g, []);
+      groups.get(g).push(id);
+    }
+    const gs = [...groups.values()];
+    const arcs = gs.map(() => new Map());
+    for (let i = 0; i < gs.length; i++) {
+      for (let j = i + 1; j < gs.length; j++) {
+        let overlap = false;
+        let gap = 0;
+        for (const a of gs[i]) {
+          for (const b of gs[j]) {
+            if (Math.abs(oCentre(a) - oCentre(b)) < oHalf(a) + oHalf(b)) overlap = true;
+            gap = Math.max(gap, (size(a) + size(b)) / 2 + pad);
+          }
+        }
+        if (!overlap) continue;
+        const mean = (g) => g.reduce((s, id) => s + centre(id), 0) / g.length;
+        const [from, to] = mean(gs[i]) <= mean(gs[j]) ? [i, j] : [j, i];
+        arcs[from].set(to, Math.max(arcs[from].get(to) ?? 0, gap));
+      }
+    }
+    return { gs, arcs };
+  };
+
+  // Merge each wire's two tables into one group — unless an arc already runs
+  // between them, meaning they overlap on the other axis, so forcing them to
+  // share a centre on this one would stack the boxes. That wire keeps its
+  // diagonal. The check runs before parent is touched: find()'s path
+  // compression inside buildArcs makes a tentative merge impossible to undo.
+  for (const [u, v] of eqEdges) {
+    const [pu, pv] = [find(u), find(v)];
+    if (pu === pv) continue;
+    const { gs, arcs } = buildArcs();
+    const at = new Map(gs.map((g, i) => [find(g[0]), i]));
+    const [iu, iv] = [at.get(pu), at.get(pv)];
+    if (arcs[iu].has(iv) || arcs[iv].has(iu)) continue;
+    parent.set(pu, pv);
+  }
+
+  // Longest-path assignment: source groups hold their current coordinate and
+  // every other group sits exactly one gap past its predecessors, so the
+  // solve compacts towards the anchors rather than only ever pushing apart.
+  const { gs, arcs } = buildArcs();
+  const indeg = arcs.map(() => 0);
+  for (const tos of arcs) for (const t of tos.keys()) indeg[t]++;
+  const queue = arcs.map((_, i) => i).filter((i) => !indeg[i]);
+  const coord = gs.map((g, i) => (indeg[i] ? -Infinity : Math.max(...g.map(centre))));
+  while (queue.length) {
+    const u = queue.shift();
+    for (const [t, gap] of arcs[u]) {
+      coord[t] = Math.max(coord[t], coord[u] + gap);
+      if (!--indeg[t]) queue.push(t);
+    }
+  }
+
+  let moved = false;
+  gs.forEach((members, i) => {
+    for (const id of members) {
+      if (Math.abs(centre(id) - coord[i]) > 0.5) moved = true;
+      setCentre(id, coord[i]);
+    }
+  });
+  return moved;
+}
+
+// Where a wire leaves a box: the compass pair, one point per box, with the
+// shortest distance between them. Mirrors the renderer's compassPair — the
+// layout is scored on the wires as they will actually be drawn, not on
+// centre-to-centre lines, which count crossings the drawn wires don't have
+// (and vice versa).
+const COMPASS8 = [
+  [1, 0.5], [1, 1], [0.5, 1], [0, 1],
+  [0, 0.5], [0, 0], [0.5, 0], [1, 0],
+];
+function anchorPair(a, b) {
+  let best = null;
+  for (const [fx, fy] of COMPASS8) {
+    for (const [gx, gy] of COMPASS8) {
+      const p = { x: a.x + fx * a.width, y: a.y + fy * a.height };
+      const q = { x: b.x + gx * b.width, y: b.y + gy * b.height };
+      const d = Math.hypot(q.x - p.x, q.y - p.y);
+      if (!best || d < best.d) best = { p, q, d };
+    }
+  }
+  return [best.p, best.q];
+}
+
+function wireSegments(springs, pos) {
+  return springs.map(([u, v]) => anchorPair(pos[u], pos[v]));
+}
+
+// Crossings between the drawn wires (pairs sharing a table fan out from one
+// box and don't count), then how far the wires sit from the ideal length.
+// Scoring raw length instead collapsed the diagram: the search packed the
+// tables together, since the shortest wire is no wire.
+function wireCost(springs, pos, ideal = 180) {
+  const segs = wireSegments(springs, pos);
+  const side = (p, q, r) => Math.sign((q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x));
+  let crossings = 0;
+  let off = 0;
+  for (let i = 0; i < segs.length; i++) {
+    const [s, t] = segs[i];
+    off += Math.abs(Math.hypot(t.x - s.x, t.y - s.y) - ideal);
+    for (let j = i + 1; j < segs.length; j++) {
+      const [u, v] = segs[j];
+      // Wires leaving the same anchor fan out from one point; not a crossing.
+      // But two wires can share a *table* and still cross, when they leave
+      // from different compass points — those count.
+      const shares = (p, q) => Math.abs(p.x - q.x) < 1 && Math.abs(p.y - q.y) < 1;
+      if (shares(s, u) || shares(t, v) || shares(s, v) || shares(t, u)) continue;
+      if (side(s, t, u) !== side(s, t, v) && side(u, v, s) !== side(u, v, t)) crossings++;
+    }
+  }
+  return crossings * 1e6 + off - alignment(springs, pos);
+}
+
+// Tables that share a neighbour read as a group when they line up — the
+// dimensions of a star forming one column beside the hub. Worth a small
+// reward, so an otherwise-even choice breaks towards the aligned arrangement.
+function alignment(springs, pos) {
+  const neighbours = new Map();
+  for (const [u, v] of springs) {
+    if (!neighbours.has(u)) neighbours.set(u, new Set());
+    if (!neighbours.has(v)) neighbours.set(v, new Set());
+    neighbours.get(u).add(v);
+    neighbours.get(v).add(u);
+  }
+  const ids = [...neighbours.keys()];
+  let bonus = 0;
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const shared = [...neighbours.get(ids[i])].some((id) => neighbours.get(ids[j]).has(id));
+      if (!shared) continue;
+      const a = pos[ids[i]];
+      const b = pos[ids[j]];
+      if (Math.abs(a.x + a.width / 2 - (b.x + b.width / 2)) < 1) bonus += 60;
+      if (Math.abs(a.y + a.height / 2 - (b.y + b.height / 2)) < 1) bonus += 60;
+    }
+  }
+  return bonus;
+}
+
+function anyOverlap(pos, ids, pad = BOX_GAP) {
+  for (let i = 0; i < ids.length; i++) {
+    for (let j = i + 1; j < ids.length; j++) {
+      const a = pos[ids[i]];
+      const b = pos[ids[j]];
+      const ox = (a.width + b.width) / 2 + pad - Math.abs(a.x + a.width / 2 - (b.x + b.width / 2));
+      const oy = (a.height + b.height) / 2 + pad - Math.abs(a.y + a.height / 2 - (b.y + b.height / 2));
+      if (ox > 0 && oy > 0) return true;
+    }
+  }
+  return false;
+}
+
+function hillClimb(springs, pos, ids, grid) {
+  const STEPS = [[grid, 0], [-grid, 0], [0, grid], [0, -grid],
+                 [grid, grid], [grid, -grid], [-grid, grid], [-grid, -grid]];
+  let cost = wireCost(springs, pos);
+  for (let round = 0; round < 20; round++) {
+    let improved = false;
+    for (const id of ids) {
+      const n = pos[id];
+      for (const [dx, dy] of STEPS) {
+        n.x += dx;
+        n.y += dy;
+        if (anyOverlap(pos, ids)) {
+          n.x -= dx;
+          n.y -= dy;
+          continue;
+        }
+        const now = wireCost(springs, pos);
+        if (now < cost) {
+          cost = now;
+          improved = true;
+        } else {
+          n.x -= dx;
+          n.y -= dy;
+        }
+      }
+    }
+    if (!improved) break;
+  }
+}
+
+// Stress terms act on centres and know nothing of box sizes, so two
+// tables can settle on top of each other. Push overlapping pairs apart along
+// the axis that moves them least, repeating until nothing overlaps. Returns
+// whether anything had to move.
+function separate(nodes, ids, pad = BOX_GAP) {
+  for (let round = 0; round < 100; round++) {
+    let moved = false;
+    for (let i = 0; i < ids.length; i++) {
+      for (let j = i + 1; j < ids.length; j++) {
+        const a = nodes[ids[i]];
+        const b = nodes[ids[j]];
+        const ox = (a.width + b.width) / 2 + pad - Math.abs(a.x + a.width / 2 - (b.x + b.width / 2));
+        const oy = (a.height + b.height) / 2 + pad - Math.abs(a.y + a.height / 2 - (b.y + b.height / 2));
+        if (ox <= 0 || oy <= 0) continue;
+        moved = true;
+        if (ox < oy) {
+          const push = ox / 2 * Math.sign(a.x - b.x || (ids[i] < ids[j] ? -1 : 1));
+          a.x += push;
+          b.x -= push;
+        } else {
+          const push = oy / 2 * Math.sign(a.y - b.y || (ids[i] < ids[j] ? -1 : 1));
+          a.y += push;
+          b.y -= push;
+        }
+      }
+    }
+    if (!moved) return false;
+  }
+  return true;
+}
 
 // Unattached tables flow left to right and wrap, filling as many columns as the
 // board is wide.


### PR DESCRIPTION
Experimental solution to #214.

Adds a **minimal mode** to the rendered dictionary page (toggle in the diagram toolbar, persisted per dictionary in localStorage): each table draws as its name only, one wire per relationship, laid out by a full stress model rather than dagre.

## Layout pipeline (minimal mode)

1. **Stress model solved by SGD** — Zheng, Pawar & Goodman, *Graph Drawing by Stochastic Gradient Descent* (IEEE TVCG 2019, arXiv:1710.04626, s_gd2). All-pairs shortest-path ideal distances, weighted 1/d², inflated by box half-extents (Gansner & Hu) so the stress term itself keeps boxes apart; s_gd2 exponential annealing schedule; 8 deterministic restarts (seeded PRNG) scored on wire crossings of the wires as actually drawn.
2. **Constraint-graph align/straighten** — the coordinate-assignment half of Shape-Metrics (arXiv:2508.19416) reduced to what rectangle nodes need, no SAT: wires are compass-labelled, H/V wires become centre-equality constraints, non-overlap becomes separation arcs in a per-axis DAG, longest path assigns coordinates and compacts. A merge is refused when an arc already runs between the two groups (they overlap on the other axis, so sharing a centre would stack the boxes) — that wire keeps its diagonal, which the renderer draws happily.
3. **Hill-climb polish** on a cost of wire crossings + deviation from ideal length − alignment bonus.

## Wire anchoring

Minimal-mode wires anchor to the nearest pair of compass points (3×3 grid: corners + edge midpoints) on the two boxes — aligned boxes get facing edge midpoints, so straight wires draw exactly straight. The layout's crossing scoring mirrors the same anchor choice.

## Notes

- One shared `BOX_GAP` constant feeds the solver, the hill-climb's overlap test, and the separation pass, so they don't re-move each other's placements.
- `tidy` discards the saved arrangement but preserves the mode.
- Reviewer findings addressed: literal NUL byte replaced with a `\0` escape (git treats the file as text again), dead acyclicity merge check replaced with the correct arc-between-groups infeasibility test (verified on the triangle repro), latent union-find revert corruption eliminated by checking feasibility before mutating `parent`.