### PR TITLE
Report offending values for uniqueness checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ If a schema change causes `site/examples/` to fail, don't fix them. Instead repo
 A column marked `display: restricted` holds sensitive data (typically PII), and **no value the data held may ever appear in tool output** — exports, rendered HTML, or diagnostics. Enforcement lives in two places:
 
 - `ExportProfile::restrict()` (`export.rs`) strips `sample_values`/`common_values`/`range`/`histogram` from a restricted column's profile, keeping only counts (`missing`, `distinct`). The website renders through this export, so gating here covers it.
-- `is_restricted()` (`validate_data.rs`) withholds offending-value samples from D04/D05 diagnostics (message and `ProblemKind::values` alike).
+- `is_restricted()` (`validate_data.rs`) withholds offending-value samples from the D02/D04/D05/D07 diagnostics (message and `ProblemKind::values` alike). Withholding is per column: a restricted column drops out of every [`ValueRow`](crates/data-dict/src/problem.rs), while the unrestricted columns beside it in a composite key or an assertion keep their values. Each of those kinds carries `redacted`, saying whether anything was withheld.
 
 Any new feature that moves data values toward the user — a new profile statistic, a new export field, a new diagnostic that quotes values — must gate on `display` the same way. Author-declared `examples`/`range` are the author's responsibility (the spec requires fakes); only data-derived values are gated.
 

--- a/crates/data-dict-parquet/src/display.rs
+++ b/crates/data-dict-parquet/src/display.rs
@@ -1,10 +1,26 @@
 //! Human-readable value rendering for diagnostic samples, via arrow's
 //! type-aware formatter (dates render as dates, decimals at their scale).
 
-use arrow_array::Array;
+use arrow_array::{Array, ArrayRef};
+use arrow_cast::cast;
 use arrow_cast::display::{ArrayFormatter, FormatOptions};
+use arrow_schema::DataType;
 
 use crate::ParquetError;
+
+/// The form a column is rendered from. A timestamp's timezone label is dropped,
+/// leaving the instant it names: the label doesn't change the stored value, and
+/// naming a zone needs a timezone database arrow is not built with. Every other
+/// array renders as it stands.
+pub(crate) fn display_form(array: &ArrayRef) -> ArrayRef {
+    match array.data_type() {
+        DataType::Timestamp(unit, Some(_)) => {
+            let naive = DataType::Timestamp(*unit, None);
+            cast(array, &naive).unwrap_or_else(|_| array.clone())
+        }
+        _ => array.clone(),
+    }
+}
 
 pub(crate) struct Values<'a> {
     formatter: ArrayFormatter<'a>,

--- a/crates/data-dict-parquet/src/foreign_key.rs
+++ b/crates/data-dict-parquet/src/foreign_key.rs
@@ -17,7 +17,7 @@ use arrow_schema::{DataType, TimeUnit};
 use rayon::prelude::*;
 
 use crate::ParquetError;
-use crate::display::Values;
+use crate::display::{Values, display_form};
 use crate::keys::{KeyColumn, KeySet, canonicalize};
 use crate::metadata::Comparability;
 use crate::reader::FileContext;
@@ -44,8 +44,8 @@ pub enum ForeignKeyResult {
 }
 
 /// Values found in the child column that are absent from the parent column.
-/// `orphan_rows`/`orphan_values` sample the first few (1-based rows, distinct
-/// values); `orphan_count` is the total.
+/// `orphan_rows` samples the first few (1-based) and `orphan_values` the value
+/// each of those rows held; `orphan_count` is the total.
 #[derive(Default)]
 pub struct ForeignKeyStats {
     pub orphan_count: usize,
@@ -121,8 +121,8 @@ fn check_foreign_key(
     let mut row_offset = 0usize;
     for batch in child.reader([child_leaf])? {
         let batch = batch?;
-        let original = batch.column(0);
-        let casted = canonicalize(&cast(original, &target)?);
+        let original = display_form(batch.column(0));
+        let casted = canonicalize(&cast(&original, &target)?);
         let keys = KeyColumn::new(&casted)?;
         let seen = seen.get_or_insert_with(|| KeySet::for_column(&keys, 0));
         let mut values: Option<Values> = None;
@@ -175,18 +175,13 @@ fn orphan_all(
 
 impl ForeignKeyStats {
     /// Record the orphan at 0-based `row`, sampling its 1-based row number and
-    /// distinct rendered value up to `sample_limit`. `value` is only rendered
-    /// while the value sample can still grow.
+    /// rendered value up to `sample_limit`. `value` is only rendered while the
+    /// sample can still grow.
     fn orphan(&mut self, row: usize, value: impl FnOnce() -> String, sample_limit: usize) {
         self.orphan_count += 1;
         if self.orphan_rows.len() < sample_limit {
             self.orphan_rows.push(row + 1);
-        }
-        if self.orphan_values.len() < sample_limit {
-            let value = value();
-            if !self.orphan_values.contains(&value) {
-                self.orphan_values.push(value);
-            }
+            self.orphan_values.push(value());
         }
     }
 }

--- a/crates/data-dict-parquet/src/scan.rs
+++ b/crates/data-dict-parquet/src/scan.rs
@@ -55,8 +55,7 @@ pub struct ColumnStats {
     /// 1-based row numbers of outside values, capped by the caller's limit.
     /// A value inside a list or struct is attributed to the row holding it.
     pub outside_rows: Vec<usize>,
-    /// Distinct offending values, capped by the caller's limit, in first-seen
-    /// order.
+    /// The value each sampled row in `outside_rows` held, in the same order.
     pub outside_values: Vec<String>,
 }
 
@@ -190,9 +189,10 @@ fn row_of(offsets: &[OffsetBuffer<i32>], mut index: usize) -> usize {
     index
 }
 
-/// Test each non-null value's membership in `allowed`, recording the outsiders.
-/// Values are UTF-8 bytes; one that isn't valid UTF-8 can't be in the set (the
-/// set holds strings) and is rendered as hex for the sample.
+/// Test each non-null value's membership in `allowed`, recording the outsiders
+/// row by row, so a value that offends twice is recorded twice. Values are
+/// UTF-8 bytes; one that isn't valid UTF-8 can't be in the set (the set holds
+/// strings) and is rendered as hex for the sample.
 fn check_membership<'a>(
     values: impl Iterator<Item = Option<&'a [u8]>>,
     allowed: &HashSet<String>,
@@ -212,15 +212,10 @@ fn check_membership<'a>(
         stat.outside_count += 1;
         if stat.outside_rows.len() < limit {
             stat.outside_rows.push(row_offset + row_of(index) + 1);
-        }
-        if stat.outside_values.len() < limit {
-            let rendered = match value {
+            stat.outside_values.push(match value {
                 Some(value) => value.to_string(),
                 None => bytes.iter().map(|b| format!("{b:02x}")).collect(),
-            };
-            if !stat.outside_values.contains(&rendered) {
-                stat.outside_values.push(rendered);
-            }
+            });
         }
     }
 }

--- a/crates/data-dict-parquet/src/uniqueness.rs
+++ b/crates/data-dict-parquet/src/uniqueness.rs
@@ -1,10 +1,11 @@
 use std::path::Path;
 
-use arrow_array::{Array, ArrayRef};
+use arrow_array::{Array, ArrayRef, RecordBatch};
 use arrow_row::{RowConverter, SortField};
 use rayon::prelude::*;
 
 use crate::ParquetError;
+use crate::display::{Values, display_form};
 use crate::keys::{ByteKeys, KeyColumn, KeySet, canonicalize};
 use crate::reader::FileContext;
 
@@ -13,10 +14,20 @@ pub struct UniquenessCheck {
     pub columns: Vec<String>,
 }
 
+/// The duplicates a [`UniquenessCheck`] found. `duplicate_count` is the total;
+/// `duplicate_rows` samples the first few repeat occurrences (1-based) and
+/// `duplicate_values` the key each of those rows held, rendered in
+/// `key_columns` order. A value is rendered from the column as stored, not from
+/// the canonicalized form the comparison uses, so `-0.0` reads as it was
+/// written even though it duplicates `0.0`.
 #[derive(Default)]
 pub struct UniquenessStats {
     pub duplicate_count: usize,
     pub duplicate_rows: Vec<usize>,
+    pub duplicate_values: Vec<Vec<String>>,
+    /// The key's columns, in key order and without the repeats a caller may
+    /// have listed.
+    pub key_columns: Vec<String>,
 }
 
 /// Validate uniqueness exactly by hashing each row's key in a streaming,
@@ -65,25 +76,34 @@ fn check_uniqueness(
     // per row up front.
     let rows = ctx.rows();
     let reader = ctx.reader(leaves)?;
-    let mut stat = UniquenessStats::default();
+    let mut stat = UniquenessStats {
+        key_columns: names.iter().map(|name| (*name).to_string()).collect(),
+        ..UniquenessStats::default()
+    };
     let mut row_offset = 0usize;
 
     if let [name] = names.as_slice() {
         let mut seen: Option<KeySet> = None;
         for batch in reader {
             let batch = batch?;
-            let array = batch.column_by_name(name).expect("projected column");
-            let array = canonicalize(array);
+            let stored = batch.column_by_name(name).expect("projected column");
+            let array = canonicalize(stored);
             let keys = KeyColumn::new(&array)?;
             let seen = seen.get_or_insert_with(|| KeySet::for_column(&keys, rows));
             // Hoisted out of the row loop: `Array::is_null` is a virtual call.
             let validity = array.nulls();
+            let mut display: Option<Vec<ArrayRef>> = None;
             for row in 0..array.len() {
                 if validity.is_some_and(|v| v.is_null(row)) {
                     continue;
                 }
                 if !seen.insert(&keys, row) {
-                    record(&mut stat, row_offset + row + 1, sample_limit);
+                    let key = if stat.duplicate_rows.len() < sample_limit {
+                        sample_key(&batch, std::slice::from_ref(name), &mut display, row)?
+                    } else {
+                        Vec::new()
+                    };
+                    stat.duplicate(row_offset + row + 1, key, sample_limit);
                 }
             }
             row_offset += batch.num_rows();
@@ -113,6 +133,7 @@ fn check_uniqueness(
             // SQL uniqueness (multiple nulls are allowed) and avoiding a
             // spurious D02 alongside the D01 a required column already draws.
             let validities: Vec<_> = arrays.iter().map(|array| array.nulls()).collect();
+            let mut display: Option<Vec<ArrayRef>> = None;
             'row: for row in 0..batch.num_rows() {
                 for validity in &validities {
                     if validity.is_some_and(|v| v.is_null(row)) {
@@ -120,7 +141,12 @@ fn check_uniqueness(
                     }
                 }
                 if !seen.insert(encoded.row(row).as_ref()) {
-                    record(&mut stat, row_offset + row + 1, sample_limit);
+                    let key = if stat.duplicate_rows.len() < sample_limit {
+                        sample_key(&batch, &names, &mut display, row)?
+                    } else {
+                        Vec::new()
+                    };
+                    stat.duplicate(row_offset + row + 1, key, sample_limit);
                 }
             }
             row_offset += batch.num_rows();
@@ -129,9 +155,41 @@ fn check_uniqueness(
     Ok(stat)
 }
 
-fn record(stat: &mut UniquenessStats, row: usize, sample_limit: usize) {
-    stat.duplicate_count += 1;
-    if stat.duplicate_rows.len() < sample_limit {
-        stat.duplicate_rows.push(row);
+/// Render the key at `row`, deriving the batch's display arrays on first use.
+/// Deliberately out of line: the scan loop reaches it only for a duplicate, and
+/// only while the sample can still grow, so keeping it out of the loop body
+/// leaves the scan itself as it was before values were reported.
+#[inline(never)]
+fn sample_key(
+    batch: &RecordBatch,
+    names: &[&str],
+    display: &mut Option<Vec<ArrayRef>>,
+    row: usize,
+) -> Result<Vec<String>, ParquetError> {
+    let arrays = match display {
+        Some(arrays) => arrays,
+        None => display.insert(
+            names
+                .iter()
+                .map(|name| display_form(batch.column_by_name(name).expect("projected column")))
+                .collect(),
+        ),
+    };
+    arrays
+        .iter()
+        .map(|array| Ok(Values::new(array.as_ref())?.get(row)))
+        .collect()
+}
+
+impl UniquenessStats {
+    /// Record the duplicate at 1-based `row`, sampling it and its rendered `key`
+    /// up to `sample_limit`. The caller only renders a key while the sample can
+    /// still grow, and passes an empty one once it can't.
+    fn duplicate(&mut self, row: usize, key: Vec<String>, sample_limit: usize) {
+        self.duplicate_count += 1;
+        if self.duplicate_rows.len() < sample_limit {
+            self.duplicate_rows.push(row);
+            self.duplicate_values.push(key);
+        }
     }
 }

--- a/crates/data-dict/src/eval.rs
+++ b/crates/data-dict/src/eval.rs
@@ -26,6 +26,7 @@ use crate::assert_expr::{
     ArithOp, CmpOp, ColumnRef, DatetimeConst, LikePattern, NodeKind, Op, Shape, Type,
     TypedAssertion, TypedExpr,
 };
+use crate::problem::ValueRow;
 
 /// Days from the epoch to a date, the form dates are compared in.
 const MICROS_PER_DAY: i64 = 86_400_000_000;
@@ -133,7 +134,7 @@ pub(crate) enum Outcome {
     Rows {
         count: usize,
         rows: Vec<usize>,
-        samples: Vec<String>,
+        values: Vec<ValueRow>,
     },
     /// An aggregate or constant assertion: one verdict for the table.
     Table { holds: bool },
@@ -315,7 +316,7 @@ impl<'a> Plan<'a> {
 
         let mut count = 0usize;
         let mut rows = Vec::new();
-        let mut samples = Vec::new();
+        let mut values = Vec::new();
 
         for batch in read_typed(path, requests)? {
             let batch = batch?;
@@ -344,7 +345,7 @@ impl<'a> Plan<'a> {
                             count += 1;
                             if rows.len() < sample_limit {
                                 rows.push(absolute);
-                                samples.push(self.sample(&cx));
+                                values.push(self.sample(&cx));
                             }
                             // One row breaks the assertion once, however many
                             // selected columns break it.
@@ -359,7 +360,7 @@ impl<'a> Plan<'a> {
         Ok(Outcome::Rows {
             count,
             rows,
-            samples,
+            values,
         })
     }
 
@@ -391,13 +392,17 @@ impl<'a> Plan<'a> {
     }
 
     /// The values of the columns the expression reads, for a violating row.
-    fn sample(&self, cx: &Cx) -> String {
-        let mut parts = Vec::new();
-        for (i, column) in self.columns.iter().enumerate() {
-            let value = cx.column(i).map_or(Value::Null, |v| v);
-            parts.push(format!("{}={}", column.path.join("."), value.render()));
-        }
-        parts.join(", ")
+    /// A column the row has no value for is missing rather than rendered, so it
+    /// stays distinct from a string column holding `"null"`.
+    fn sample(&self, cx: &Cx) -> ValueRow {
+        self.columns
+            .iter()
+            .enumerate()
+            .map(|(i, column)| {
+                let value = cx.column(i).map(|value| value.render());
+                (column.path.join("."), value)
+            })
+            .collect()
     }
 }
 

--- a/crates/data-dict/src/lib.rs
+++ b/crates/data-dict/src/lib.rs
@@ -32,7 +32,9 @@ pub mod validate_spec;
 
 pub use draft::{DraftError, DraftOutcome, draft};
 pub use export::{Export, export_auto, export_data, export_spec};
-pub use problem::{Problem, ProblemKind, ProblemSet, RenderStyle, Severity, SpanLocation, Status};
+pub use problem::{
+    Problem, ProblemKind, ProblemSet, RenderStyle, Severity, SpanLocation, Status, ValueRow,
+};
 pub use quarto_source_map::SourceContext;
 pub use validate_data::validate_data;
 pub use validate_meta::validate_meta;

--- a/crates/data-dict/src/problem.rs
+++ b/crates/data-dict/src/problem.rs
@@ -122,6 +122,66 @@ pub struct Suggestion {
     pub span: SourceInfo,
 }
 
+/// One offending row's values, keyed by column name and holding only the
+/// columns the check is about. Entries keep the order the check names its
+/// columns in, which a map would lose. A `None` value is a missing one, and
+/// serializes as JSON `null` so it stays distinct from a string column holding
+/// `"null"`; only an assertion (`D07`) can report one, since the other checks
+/// exempt nulls.
+///
+/// A restricted column is left out of the row entirely, so an entry that names
+/// no columns at all means everything it would have said was withheld.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct ValueRow(Vec<(String, Option<String>)>);
+
+impl ValueRow {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Keep only the columns `keep` accepts, reporting whether any were dropped.
+    pub(crate) fn retain(&mut self, keep: impl Fn(&str) -> bool) -> bool {
+        let before = self.0.len();
+        self.0.retain(|(column, _)| keep(column));
+        self.0.len() < before
+    }
+
+    /// The values alone, in column order.
+    pub fn rendered(&self) -> impl Iterator<Item = &str> {
+        self.0.iter().map(|(_, value)| missing(value))
+    }
+
+    /// The `column=value` pairs, in column order, as an assertion reports them.
+    pub fn pairs(&self) -> impl Iterator<Item = String> {
+        self.0
+            .iter()
+            .map(|(column, value)| format!("{column}={}", missing(value)))
+    }
+}
+
+/// How a missing value reads in a rendered diagnostic, matching how an
+/// expression renders a null.
+fn missing(value: &Option<String>) -> &str {
+    value.as_deref().unwrap_or("null")
+}
+
+impl FromIterator<(String, Option<String>)> for ValueRow {
+    fn from_iter<T: IntoIterator<Item = (String, Option<String>)>>(iter: T) -> Self {
+        ValueRow(iter.into_iter().collect())
+    }
+}
+
+impl serde::Serialize for ValueRow {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeMap;
+        let mut map = serializer.serialize_map(Some(self.0.len()))?;
+        for (column, value) in &self.0 {
+            map.serialize_entry(column, value)?;
+        }
+        map.end()
+    }
+}
+
 /// A resolved source span as 0-based line/column bounds, for JSON consumers.
 /// Lines and columns count from 0, following the LSP convention; the
 /// human-rendered diagnostics show the same positions 1-based.
@@ -168,10 +228,15 @@ pub enum ProblemKind {
     /// lists the first few offending row numbers (1-based); `count` is the total.
     NullsInRequired { count: usize, rows: Vec<usize> },
     /// `D02` — a unique column or composite primary key contains duplicates.
+    /// `count` is the total; `rows` lists the first few repeat occurrences
+    /// (1-based) and `values` the key they held, one entry per listed row.
     DuplicateValues {
         columns: Vec<String>,
         count: usize,
         rows: Vec<usize>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        values: Vec<ValueRow>,
+        redacted: bool,
     },
     /// `D03` — a `unique` column or `primary_key` uses a type whose values can't
     /// be compared, so its uniqueness was not checked. `reason` is a short slug
@@ -182,23 +247,27 @@ pub enum ProblemKind {
     },
     /// `D04` — an `enum` column contains values outside its declared `values`.
     /// `count` is the total; `rows` lists the first few offending row numbers
-    /// (1-based) and `values` the first few distinct offending values.
+    /// (1-based) and `values` the value each held, one entry per listed row.
     ValuesOutsideEnum {
         count: usize,
         rows: Vec<usize>,
-        values: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        values: Vec<ValueRow>,
+        redacted: bool,
     },
     /// `D05` — a `foreign_key` column contains values absent from the
     /// `primary_key` it references. `column` is the foreign-key column,
-    /// `references` names the target as `table.column`, `count` is the total, and
-    /// `rows`/`values` sample the first few offending row numbers (1-based) and
-    /// distinct values.
+    /// `references` names the target as `table.column`, `count` is the total,
+    /// `rows` samples the first few offending row numbers (1-based) and `values`
+    /// the value each held, one entry per listed row.
     ForeignKeyNotFound {
         column: String,
         references: String,
         count: usize,
         rows: Vec<usize>,
-        values: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        values: Vec<ValueRow>,
+        redacted: bool,
     },
     /// `D06` — a `foreign_key` or the `primary_key` it references uses a type
     /// whose values can't be compared, so the reference was not checked.
@@ -210,13 +279,15 @@ pub enum ProblemKind {
         reason: String,
     },
     /// `D07` — a row-level `assert` expression is false for some rows. `rows`
-    /// lists the first few (1-based) and `samples` the values their columns
-    /// held; `count` is the total.
+    /// lists the first few (1-based) and `values` the values the columns the
+    /// expression reads held, one entry per listed row; `count` is the total.
     AssertionViolated {
         assertion: String,
         count: usize,
         rows: Vec<usize>,
-        samples: Vec<String>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        values: Vec<ValueRow>,
+        redacted: bool,
     },
     /// `D07` — an aggregate `assert` expression is false for the table. An
     /// aggregate is one verdict about every row at once, so no row is to blame.
@@ -711,6 +782,29 @@ pub(crate) fn format_rows(rows: &[usize], count: usize) -> String {
     }
 }
 
+/// Format offending values for display: `` `sleepy`, `grumpy` ``, or
+/// `` `(1, 2020-01-01)` `` once a row names more than one column. Repeats are
+/// dropped, since a reader learns nothing from seeing the same value twice —
+/// unlike the rows, which line up with [`ValueRow`]s one for one. `None` when
+/// every value was withheld as restricted.
+pub(crate) fn format_values(values: &[ValueRow]) -> Option<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for row in values {
+        if row.is_empty() {
+            continue;
+        }
+        let listed = row.rendered().collect::<Vec<_>>();
+        let text = match listed.as_slice() {
+            [only] => format!("`{only}`"),
+            many => format!("`({})`", many.join(", ")),
+        };
+        if !seen.contains(&text) {
+            seen.push(text);
+        }
+    }
+    (!seen.is_empty()).then(|| seen.join(", "))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -784,6 +878,8 @@ mod tests {
                 columns: vec!["id".into()],
                 count: 1,
                 rows: vec![2],
+                values: vec![row(&[("id", Some("x"))])],
+                redacted: false,
             }
             .code(),
             Some("D02")
@@ -792,7 +888,8 @@ mod tests {
             ProblemKind::ValuesOutsideEnum {
                 count: 1,
                 rows: vec![2],
-                values: vec!["x".into()],
+                values: vec![row(&[("status", Some("x"))])],
+                redacted: false,
             }
             .code(),
             Some("D04")
@@ -806,5 +903,48 @@ mod tests {
         assert_eq!(format_rows(&[2], 1), "row: 2");
         assert_eq!(format_rows(&[2, 5, 9], 3), "rows: 2, 5, 9");
         assert_eq!(format_rows(&[1, 2, 3, 4, 5], 8), "rows: 1, 2, 3, 4, 5, …");
+    }
+
+    fn row(pairs: &[(&str, Option<&str>)]) -> ValueRow {
+        pairs
+            .iter()
+            .map(|(column, value)| ((*column).to_string(), value.map(str::to_string)))
+            .collect()
+    }
+
+    #[test]
+    fn value_formatting() {
+        assert_eq!(
+            format_values(&[row(&[("status", Some("sleepy"))])]).as_deref(),
+            Some("`sleepy`")
+        );
+        assert_eq!(
+            format_values(&[row(&[("a", Some("1")), ("b", Some("2020-01-01"))])]).as_deref(),
+            Some("`(1, 2020-01-01)`")
+        );
+        assert_eq!(
+            format_values(&[
+                row(&[("status", Some("sleepy"))]),
+                row(&[("status", Some("sleepy"))]),
+                row(&[("status", Some("grumpy"))]),
+            ])
+            .as_deref(),
+            Some("`sleepy`, `grumpy`")
+        );
+        assert_eq!(
+            format_values(&[row(&[("weight", None)])]).as_deref(),
+            Some("`null`")
+        );
+        assert_eq!(format_values(&[ValueRow::default()]), None);
+        assert_eq!(format_values(&[]), None);
+    }
+
+    #[test]
+    fn value_row_serializes_as_an_object_in_column_order() {
+        let values = vec![row(&[("b", Some("2")), ("a", Some("1")), ("c", None)])];
+        assert_eq!(
+            serde_json::to_string(&values).unwrap(),
+            r#"[{"b":"2","a":"1","c":null}]"#
+        );
     }
 }

--- a/crates/data-dict/src/translate.rs
+++ b/crates/data-dict/src/translate.rs
@@ -15,8 +15,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use crate::assert_expr::{self, AssertExpr, DefType, Root, TypedAssertion};
-use crate::export::collect_columns;
 use crate::emit::{self, DuckDb, R_BASE, R_DATA_TABLE, R_TIDYVERSE, Target};
+use crate::export::collect_columns;
 use crate::model::{DataDict, Table};
 use crate::problem::{Problem, ProblemKind, ProblemSet};
 use crate::validate_spec::{DefEnv, resolve_definitions};

--- a/crates/data-dict/src/validate_data.rs
+++ b/crates/data-dict/src/validate_data.rs
@@ -16,7 +16,7 @@ use quarto_source_map::SourceInfo;
 
 use crate::ReadTables;
 use crate::model::{Assertion, Column, Constraint, DataDict, Table};
-use crate::problem::{Problem, ProblemKind, ProblemSet, Severity};
+use crate::problem::{Problem, ProblemKind, ProblemSet, Severity, ValueRow};
 use crate::validate_meta::CheckResult;
 
 /// How many example values (e.g. offending rows) to record per validation
@@ -26,6 +26,69 @@ const SAMPLE_LIMIT: usize = 5;
 /// A `display: restricted` column's values never appear in diagnostics.
 fn is_restricted(col: &Column) -> bool {
     col.display.as_deref() == Some("restricted")
+}
+
+/// Pair each sampled row's values with the columns they came from, leaving out
+/// every column `restricted` names. Withholding is per column, so a key's
+/// unrestricted columns still report their values; a row left naming nothing at
+/// all is dropped, since an empty entry says nothing.
+///
+/// Returns the rows and whether anything was withheld, which the problem
+/// reports as `redacted`.
+fn value_rows(
+    columns: &[String],
+    values: &[Vec<String>],
+    restricted: impl Fn(&str) -> bool,
+) -> (Vec<ValueRow>, bool) {
+    let kept: Vec<bool> = columns.iter().map(|name| !restricted(name)).collect();
+    let redacted = kept.iter().any(|keep| !keep);
+    let rows = values
+        .iter()
+        .map(|value| {
+            columns
+                .iter()
+                .zip(value)
+                .zip(&kept)
+                .filter(|(_, keep)| **keep)
+                .map(|((name, value), _)| (name.clone(), Some(value.clone())))
+                .collect::<ValueRow>()
+        })
+        .filter(|row| !row.is_empty())
+        .collect();
+    (rows, redacted)
+}
+
+/// Withhold the values of every restricted column an assertion reads, dropping
+/// a row left naming nothing. An assertion names its columns by path, and only
+/// a whole column can be restricted, so the root segment decides.
+fn restrict_assertion_values(table: &Table, values: Vec<ValueRow>) -> (Vec<ValueRow>, bool) {
+    let restricted = |path: &str| {
+        let root = path.split('.').next().unwrap_or(path);
+        table
+            .columns
+            .iter()
+            .any(|col| col.name.value == root && is_restricted(col))
+    };
+    let mut redacted = false;
+    let mut kept = Vec::new();
+    for mut row in values {
+        redacted |= row.retain(|column| !restricted(column));
+        if !row.is_empty() {
+            kept.push(row);
+        }
+    }
+    (kept, redacted)
+}
+
+/// The `(values; rows)` tail every value-reporting diagnostic ends with, naming
+/// the offending values when they can be shown and saying so when they can't.
+fn found(values: &[ValueRow], rows: &[usize], count: usize, redacted: bool) -> String {
+    let listed = crate::problem::format_rows(rows, count);
+    match crate::problem::format_values(values) {
+        Some(values) => format!("{values}; {listed}"),
+        None if redacted => format!("values restricted; {listed}"),
+        None => listed,
+    }
 }
 
 /// Validate a parquet file's values against a data dictionary.
@@ -120,9 +183,9 @@ fn value_issues(
     let stats = data_dict_parquet::column_stats(parquet_path, &requests, SAMPLE_LIMIT)?;
 
     // Phase 3 — check. Per planned column, draw verdicts from the gathered stats.
-    for ((_, col, pending), stat) in plan.iter().zip(&stats) {
+    for ((request, col, pending), stat) in plan.iter().zip(&stats) {
         for check in pending {
-            if let Some(problem) = check.check_data(table, col, stat) {
+            if let Some(problem) = check.check_data(table, col, &request.path, stat) {
                 out.push(problem);
             }
         }
@@ -322,11 +385,16 @@ fn assertion_problem(
         crate::eval::Outcome::Rows {
             count,
             rows,
-            samples,
+            values,
         } => {
+            let (values, redacted) = restrict_assertion_values(table, values);
             let plural = if count == 1 { "" } else { "s" };
             let listed = list_rows(&rows, count);
-            let sample = samples.first().map_or(String::new(), |s| format!(" ({s})"));
+            let sample = values
+                .first()
+                .map(|row| row.pairs().collect::<Vec<_>>().join(", "))
+                .or_else(|| redacted.then(|| "values restricted".to_string()))
+                .map_or(String::new(), |sample| format!(" ({sample})"));
             (
                 format!("is false for {count} row{plural}: {listed}{sample}"),
                 "An assertion must hold for every row.",
@@ -334,7 +402,8 @@ fn assertion_problem(
                     assertion: text,
                     count,
                     rows,
-                    samples,
+                    values,
+                    redacted,
                 },
             )
         }
@@ -463,10 +532,18 @@ trait ColumnCheck {
 
     /// Draw a verdict from the gathered stats. Only ever called with stats whose
     /// requested fields this check (or another) asked for. `table` is passed for
-    /// locating the finding at the column's node in the dictionary.
+    /// locating the finding at the column's node in the dictionary, and `path`
+    /// names the column as the data holds it — several segments for a field
+    /// reached through a struct.
     /// Complete an inconclusive metadata check from scanned values. `None` is
     /// pass and `Some` is fail; data checks cannot remain inconclusive.
-    fn check_data(&self, table: &Table, col: &Column, stats: &ColumnStats) -> Option<Problem>;
+    fn check_data(
+        &self,
+        table: &Table,
+        col: &Column,
+        path: &[String],
+        stats: &ColumnStats,
+    ) -> Option<Problem>;
 }
 
 /// Every value-level check, run against each present column. Add a check here
@@ -488,7 +565,13 @@ impl ColumnCheck for RequiredNotNull {
         }
     }
 
-    fn check_data(&self, table: &Table, col: &Column, stats: &ColumnStats) -> Option<Problem> {
+    fn check_data(
+        &self,
+        table: &Table,
+        col: &Column,
+        _path: &[String],
+        stats: &ColumnStats,
+    ) -> Option<Problem> {
         // Nulls are only counted when this check requested them (i.e. the column
         // is required), so a positive count is exactly a violation.
         if stats.null_count == 0 {
@@ -531,13 +614,19 @@ impl ColumnCheck for EnumMembership {
         }
     }
 
-    fn check_data(&self, table: &Table, col: &Column, stats: &ColumnStats) -> Option<Problem> {
+    fn check_data(
+        &self,
+        table: &Table,
+        col: &Column,
+        path: &[String],
+        stats: &ColumnStats,
+    ) -> Option<Problem> {
         // The set was only requested for enum columns, so any outside value is a
         // violation.
         if stats.outside_count == 0 {
             return None;
         }
-        Some(values_outside_enum(table, col, stats))
+        Some(values_outside_enum(table, col, path, stats))
     }
 }
 
@@ -555,21 +644,31 @@ fn enum_allowed(col: &Column) -> Option<HashSet<String>> {
     )
 }
 
-fn values_outside_enum(table: &Table, col: &Column, stats: &ColumnStats) -> Problem {
+fn values_outside_enum(
+    table: &Table,
+    col: &Column,
+    path: &[String],
+    stats: &ColumnStats,
+) -> Problem {
     let count = stats.outside_count;
-    let rows = crate::problem::format_rows(&stats.outside_rows, count);
+    let rowwise: Vec<Vec<String>> = stats
+        .outside_values
+        .iter()
+        .map(|value| vec![value.clone()])
+        .collect();
+    // The schema allows `display` on a column but not on a nested field, so a
+    // field reached through a struct takes its restriction from the column that
+    // holds it.
+    let restricted = is_restricted(col)
+        || path.first().is_some_and(|root| {
+            table
+                .columns
+                .iter()
+                .any(|col| col.name.value == *root && is_restricted(col))
+        });
+    let (values, redacted) = value_rows(&[path.join(".")], &rowwise, |_| restricted);
+    let detail = found(&values, &stats.outside_rows, count, redacted);
     let plural = if count == 1 { "" } else { "s" };
-    let restricted = is_restricted(col);
-    let sample = if restricted {
-        "values restricted".to_string()
-    } else {
-        stats
-            .outside_values
-            .iter()
-            .map(|value| format!("`{value}`"))
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
     let values_span = col
         .values
         .as_ref()
@@ -577,7 +676,7 @@ fn values_outside_enum(table: &Table, col: &Column, stats: &ColumnStats) -> Prob
     Problem {
         code: Some("D04"),
         severity: Severity::Error,
-        message: format!("has {count} value{plural} outside the allowed set ({sample}; {rows})"),
+        message: format!("has {count} value{plural} outside the allowed set ({detail})"),
         column: None,
         expected: Some("An enum column's values must all be among its declared `values`.".into()),
         hint: None,
@@ -586,11 +685,8 @@ fn values_outside_enum(table: &Table, col: &Column, stats: &ColumnStats) -> Prob
         kind: ProblemKind::ValuesOutsideEnum {
             count,
             rows: stats.outside_rows.clone(),
-            values: if restricted {
-                Vec::new()
-            } else {
-                stats.outside_values.clone()
-            },
+            values,
+            redacted,
         },
     }
 }
@@ -630,7 +726,10 @@ fn nulls_in_required_data(table: &Table, col: &Column, count: usize, rows: Vec<u
 
 fn duplicates_in_unique_column(table: &Table, col: &Column, stats: &UniquenessStats) -> Problem {
     let count = stats.duplicate_count;
-    let detail = crate::problem::format_rows(&stats.duplicate_rows, count);
+    let (values, redacted) = value_rows(&stats.key_columns, &stats.duplicate_values, |_| {
+        is_restricted(col)
+    });
+    let detail = found(&values, &stats.duplicate_rows, count, redacted);
     let plural = if count == 1 { "" } else { "s" };
     let constraint_span = col
         .constraints
@@ -657,6 +756,8 @@ fn duplicates_in_unique_column(table: &Table, col: &Column, stats: &UniquenessSt
             columns: vec![col.name.value.clone()],
             count,
             rows: stats.duplicate_rows.clone(),
+            values,
+            redacted,
         },
     }
 }
@@ -667,7 +768,12 @@ fn duplicates_in_primary_key(
     stats: &UniquenessStats,
 ) -> Problem {
     let count = stats.duplicate_count;
-    let detail = crate::problem::format_rows(&stats.duplicate_rows, count);
+    let (values, redacted) = value_rows(&stats.key_columns, &stats.duplicate_values, |name| {
+        columns
+            .iter()
+            .any(|col| col.name.value == name && is_restricted(col))
+    });
+    let detail = found(&values, &stats.duplicate_rows, count, redacted);
     let plural = if count == 1 { "" } else { "s" };
     let last = columns
         .last()
@@ -696,6 +802,8 @@ fn duplicates_in_primary_key(
             columns: columns.iter().map(|col| col.name.value.clone()).collect(),
             count,
             rows: stats.duplicate_rows.clone(),
+            values,
+            redacted,
         },
     }
 }
@@ -865,26 +973,21 @@ fn foreign_key_not_found(
     stats: &ForeignKeyStats,
 ) -> Problem {
     let count = stats.orphan_count;
-    let detail = crate::problem::format_rows(&stats.orphan_rows, count);
+    let rowwise: Vec<Vec<String>> = stats
+        .orphan_values
+        .iter()
+        .map(|value| vec![value.clone()])
+        .collect();
+    let (values, redacted) = value_rows(std::slice::from_ref(&col.name.value), &rowwise, |_| {
+        is_restricted(col)
+    });
+    let detail = found(&values, &stats.orphan_rows, count, redacted);
     let plural = if count == 1 { "" } else { "s" };
-    let restricted = is_restricted(col);
-    let sample = if restricted {
-        "values restricted".to_string()
-    } else {
-        stats
-            .orphan_values
-            .iter()
-            .map(|value| format!("`{value}`"))
-            .collect::<Vec<_>>()
-            .join(", ")
-    };
     let references = format!("{}.{}", parent_table.name.value, parent_col.name.value);
     Problem {
         code: Some("D05"),
         severity: Severity::Error,
-        message: format!(
-            "has {count} value{plural} not found in `{references}` ({sample}; {detail})"
-        ),
+        message: format!("has {count} value{plural} not found in `{references}` ({detail})"),
         column: None,
         expected: Some(
             "A foreign key's values must all appear in the primary key it references.".into(),
@@ -901,11 +1004,8 @@ fn foreign_key_not_found(
             references,
             count,
             rows: stats.orphan_rows.clone(),
-            values: if restricted {
-                Vec::new()
-            } else {
-                stats.orphan_values.clone()
-            },
+            values,
+            redacted,
         },
     }
 }

--- a/crates/data-dict/src/validate_meta.rs
+++ b/crates/data-dict/src/validate_meta.rs
@@ -200,6 +200,10 @@ fn duplicates_meta(table: &Table, col: &Column, count: usize) -> Problem {
             columns: vec![col.name.value.clone()],
             count,
             rows: Vec::new(),
+            // The footer proves how many rows repeat but not which, so there is
+            // no row to read a value from.
+            values: Vec::new(),
+            redacted: false,
         },
     }
 }

--- a/crates/data-dict/tests/snapshots/validate_data__assertion_values_withheld_when_restricted.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__assertion_values_withheld_when_restricted.snap
@@ -1,0 +1,27 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    constraints:
+      - assert: a > 0
+    columns:
+      - name: a
+        type: number(quantity)
+        range: [-1000000, 1000000]
+        display: restricted
+      - name: b
+        type: number(quantity)
+        range: [-1000000, 1000000]
+────────────────────────────────────────
+error[D07]: An assertion must hold for every row.
+  --> dict.yaml:8:17
+   |
+LL |   - name: t
+...
+LL |       - assert: a > 0
+   |                 ^^^^^ is false for 1 row: 2 (values restricted)

--- a/crates/data-dict/tests/snapshots/validate_data__assertion_withholds_only_its_restricted_column.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__assertion_withholds_only_its_restricted_column.snap
@@ -1,0 +1,27 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    constraints:
+      - assert: a > 0 OR b > 100
+    columns:
+      - name: a
+        type: number(quantity)
+        range: [-1000000, 1000000]
+        display: restricted
+      - name: b
+        type: number(quantity)
+        range: [-1000000, 1000000]
+────────────────────────────────────────
+error[D07]: An assertion must hold for every row.
+  --> dict.yaml:8:17
+   |
+LL |   - name: t
+...
+LL |       - assert: a > 0 OR b > 100
+   |                 ^^^^^^^^^^^^^^^^ is false for 1 row: 2 (b=20)

--- a/crates/data-dict/tests/snapshots/validate_data__composite_key_withholds_only_its_restricted_column.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__composite_key_withholds_only_its_restricted_column.snap
@@ -1,0 +1,31 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    columns:
+      - name: a
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+      - name: b
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+        display: restricted
+────────────────────────────────────────
+error[D02]: The primary key must uniquely identify every row.
+  --> dict.yaml:14:23
+   |
+LL |   - name: t
+...
+LL |       - name: a
+...
+LL |       - name: b
+LL |         type: number(id)
+LL |         constraints: [primary_key]
+   |                       ^^^^^^^^^^^ has 1 repeated occurrence (`1.0`; row: 2)

--- a/crates/data-dict/tests/snapshots/validate_data__duplicate_values_withheld_when_restricted.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__duplicate_values_withheld_when_restricted.snap
@@ -1,0 +1,25 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    columns:
+      - name: email
+        type: string
+        constraints: [unique]
+        examples: ['x@example.com']
+        display: restricted
+────────────────────────────────────────
+error[D02]: A unique column must not contain duplicate values.
+  --> dict.yaml:10:23
+   |
+LL |   - name: t
+...
+LL |       - name: email
+LL |         type: string
+LL |         constraints: [unique]
+   |                       ^^^^^^ has 1 repeated occurrence (values restricted; row: 2)

--- a/crates/data-dict/tests/snapshots/validate_data__every_offending_enum_row_reports_its_value.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__every_offending_enum_row_reports_its_value.snap
@@ -1,0 +1,23 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    columns:
+      - name: status
+        type: enum
+        values: [active]
+────────────────────────────────────────
+error[D04]: An enum column's values must all be among its declared `values`.
+  --> dict.yaml:10:17
+   |
+LL |   - name: t
+...
+LL |       - name: status
+LL |         type: enum
+LL |         values: [active]
+   |                 ^^^^^^^^ has 3 values outside the allowed set (`sleepy`, `grumpy`; rows: 2, 3, 4)

--- a/crates/data-dict/tests/snapshots/validate_data__every_orphan_row_reports_its_value.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__every_orphan_row_reports_its_value.snap
@@ -1,0 +1,35 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: item
+    source:
+      parquet: item.parquet
+    columns:
+      - name: category_id
+        type: number(id)
+        constraints: [foreign_key]
+        examples: [1, 2]
+  - name: category
+    source:
+      parquet: category.parquet
+    columns:
+      - name: id
+        type: number(id)
+        constraints: [primary_key]
+        examples: [1, 2]
+relationships:
+  - join: item.category_id = category.id
+    cardinality: many-to-one
+────────────────────────────────────────
+error[D05]: A foreign key's values must all appear in the primary key it references.
+  --> dict.yaml:10:23
+   |
+LL |   - name: item
+...
+LL |       - name: category_id
+LL |         type: number(id)
+LL |         constraints: [foreign_key]
+   |                       ^^^^^^^^^^^ has 2 values not found in `category.id` (`5`; rows: 1, 3)

--- a/crates/data-dict/tests/snapshots/validate_data__every_repeat_of_a_key_is_reported.snap
+++ b/crates/data-dict/tests/snapshots/validate_data__every_repeat_of_a_key_is_reported.snap
@@ -1,0 +1,24 @@
+---
+source: crates/data-dict/tests/validate_data.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+tables:
+  - name: t
+    source:
+      parquet: data.parquet
+    columns:
+      - name: code
+        type: string
+        constraints: [unique]
+        examples: [a, b]
+────────────────────────────────────────
+error[D02]: A unique column must not contain duplicate values.
+  --> dict.yaml:10:23
+   |
+LL |   - name: t
+...
+LL |       - name: code
+LL |         type: string
+LL |         constraints: [unique]
+   |                       ^^^^^^ has 2 repeated occurrences (`a`; rows: 2, 4)

--- a/crates/data-dict/tests/validate_data.rs
+++ b/crates/data-dict/tests/validate_data.rs
@@ -12,7 +12,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use data_dict::{Problem, ProblemKind, ProblemSet, Status, validate_data, validate_meta};
+use data_dict::{Problem, ProblemKind, ProblemSet, Status, ValueRow, validate_data, validate_meta};
 use indoc::{formatdoc, indoc};
 use parquet::data_type::{
     ByteArray, ByteArrayType, DoubleType, FixedLenByteArray, FixedLenByteArrayType, Int32Type,
@@ -21,6 +21,15 @@ use parquet::data_type::{
 use parquet::file::properties::{EnabledStatistics, WriterProperties};
 use parquet::file::writer::{SerializedColumnWriter, SerializedFileWriter};
 use parquet::schema::parser::parse_message_type;
+
+/// The values each sampled row held, a composite key's columns joined with a
+/// comma. A row whose every column was withheld as restricted reads as empty.
+fn sampled(values: &[ValueRow]) -> Vec<String> {
+    values
+        .iter()
+        .map(|row| row.rendered().collect::<Vec<_>>().join(", "))
+        .collect()
+}
 
 /// Validate a single column's values in isolation, via [`build_column`].
 fn check_column(
@@ -101,6 +110,11 @@ fn write_double_with_null(col: &mut SerializedColumnWriter) {
 }
 
 fn build_composite_key(first: &[f64], second: &[f64]) -> PathBuf {
+    build_composite_key_with_display(first, second, "")
+}
+
+/// [`build_composite_key`], with `display` spliced into key column `b`'s entry.
+fn build_composite_key_with_display(first: &[f64], second: &[f64], display: &str) -> PathBuf {
     let dir = temp_dir();
     let parquet = dir.join("data.parquet");
     let schema = Arc::new(
@@ -126,7 +140,7 @@ fn build_composite_key(first: &[f64], second: &[f64]) -> PathBuf {
 
     write_dict(
         &dir,
-        indoc! {"
+        &formatdoc! {"
             tables:
               - name: t
                 source:
@@ -139,7 +153,7 @@ fn build_composite_key(first: &[f64], second: &[f64]) -> PathBuf {
                   - name: b
                     type: number(id)
                     constraints: [primary_key]
-                    examples: [1, 2]
+                    examples: [1, 2]{display}
         "},
     )
 }
@@ -306,9 +320,9 @@ fn values_outside_enum_reported() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D04"),
-                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values },
+                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[4] && values == &["sleepy"]
+            }] if rows == &[4] && sampled(values) == ["sleepy"]
         ),
         "got {:?}",
         result.items
@@ -318,6 +332,39 @@ fn values_outside_enum_reported() {
         &yaml,
         &result.render(common::SNAPSHOT_STYLE).join("\n")
     ));
+}
+
+/// `values` line up with `rows` one for one, so a value that offends twice is
+/// reported twice even though the message names it once.
+#[test]
+fn every_offending_enum_row_reports_its_value() {
+    let yaml = build_column(
+        "REQUIRED BYTE_ARRAY status (UTF8)",
+        write_strings(&["active", "sleepy", "sleepy", "grumpy"]),
+        indoc! {"
+            - name: status
+              type: enum
+              values: [active]
+        "},
+    );
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D04"),
+                kind: ProblemKind::ValuesOutsideEnum { count: 3, rows, values, .. },
+                ..
+            }] if rows == &[2, 3, 4] && sampled(values) == ["sleepy", "sleepy", "grumpy"]
+        ),
+        "got {:?}",
+        result.items
+    );
+    let diagnostic = common::diagnostic(&yaml, &result.render(common::SNAPSHOT_STYLE).join("\n"));
+    diagnostic.assert_contains(&["D04", "(`sleepy`, `grumpy`; rows: 2, 3, 4)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
 }
 
 /// A restricted column's offending values are withheld from both the message
@@ -342,7 +389,7 @@ fn values_outside_enum_withheld_when_restricted() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D04"),
-                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values },
+                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. },
                 ..
             }] if rows == &[4] && values.is_empty()
         ),
@@ -390,9 +437,9 @@ fn enum_map_form_values_are_the_keys() {
         matches!(
             result.items.as_slice(),
             [Problem {
-                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values },
+                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[2] && values == &["Active"]
+            }] if rows == &[2] && sampled(values) == ["Active"]
         ),
         "got {:?}",
         result.items
@@ -453,9 +500,9 @@ fn true_parquet_enum_column_is_checked() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D04"),
-                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values },
+                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[2] && values == &["other"]
+            }] if rows == &[2] && sampled(values) == ["other"]
         ),
         "got {:?}",
         result.items
@@ -594,9 +641,9 @@ fn enum_without_dictionary_encoding_falls_back_to_scan() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D04"),
-                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values },
+                kind: ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[3] && values == &["sleepy"]
+            }] if rows == &[3] && sampled(values) == ["sleepy"]
         ),
         "got {:?}",
         result.items
@@ -653,10 +700,71 @@ fn duplicate_values_in_unique_column_reported() {
         result.items.as_slice(),
         [Problem {
             code: Some("D02"),
-            kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+            kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
             ..
-        }] if columns == &["id"] && rows == &[2]
+        }] if columns == &["id"] && rows == &[2] && sampled(values) == ["1.0"]
     ));
+}
+
+/// `values` line up with `rows` one for one, nothing deduplicated, so a key
+/// repeated twice is reported twice.
+#[test]
+fn every_repeat_of_a_key_is_reported() {
+    let yaml = build_string_groups(&[&["a", "a", "b", "a"]]);
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D02"),
+                kind: ProblemKind::DuplicateValues { count: 2, rows, values, .. },
+                ..
+            }] if rows == &[2, 4] && sampled(values) == ["a", "a"]
+        ),
+        "got {:?}",
+        result.items
+    );
+    let diagnostic = common::diagnostic(&yaml, &result.render(common::SNAPSHOT_STYLE).join("\n"));
+    diagnostic.assert_contains(&["D02", "has 2 repeated occurrences (`a`; rows: 2, 4)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+/// A restricted column's duplicate values are withheld from both the message
+/// and the structured kind. The rows stay, so the records are still findable by
+/// anyone entitled to read them.
+#[test]
+fn duplicate_values_withheld_when_restricted() {
+    let yaml = build_column(
+        "REQUIRED BYTE_ARRAY email (UTF8)",
+        write_strings(&["a@example.com", "a@example.com"]),
+        indoc! {"
+            - name: email
+              type: string
+              constraints: [unique]
+              examples: ['x@example.com']
+              display: restricted
+        "},
+    );
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D02"),
+                kind: ProblemKind::DuplicateValues { count: 1, rows, values, redacted: true, .. },
+                ..
+            }] if rows == &[2] && values.is_empty()
+        ),
+        "got {:?}",
+        result.items
+    );
+    let rendered = result.render(common::SNAPSHOT_STYLE).join("\n");
+    assert!(!rendered.contains("a@example.com"), "got {rendered}");
+    #[cfg(unix)]
+    assert_snapshot!(common::diagnostic(&yaml, &rendered));
 }
 
 /// Write a single required string column whose values are split across the
@@ -717,9 +825,9 @@ fn duplicate_string_values_across_row_groups_reported() {
         result.items.as_slice(),
         [Problem {
             code: Some("D02"),
-            kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+            kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
             ..
-        }] if columns == &["code"] && rows == &[4]
+        }] if columns == &["code"] && rows == &[4] && sampled(values) == ["a"]
     ));
 }
 
@@ -734,10 +842,39 @@ fn composite_primary_key_is_checked_collectively() {
         result.items.as_slice(),
         [Problem {
             code: Some("D02"),
-            kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+            kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
             ..
-        }] if columns == &["a", "b"] && rows == &[2]
+        }] if columns == &["a", "b"] && rows == &[2] && sampled(values) == ["1.0, 1.0"]
     ));
+}
+
+/// Withholding is per column: the restricted key column drops out of the
+/// reported key while its neighbour still names its value.
+#[test]
+fn composite_key_withholds_only_its_restricted_column() {
+    let yaml = build_composite_key_with_display(
+        &[1.0, 1.0, 2.0],
+        &[1.0, 1.0, 2.0],
+        "\n        display: restricted",
+    );
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D02"),
+                kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, redacted: true },
+                ..
+            }] if columns == &["a", "b"] && rows == &[2] && sampled(values) == ["1.0"]
+        ),
+        "got {:?}",
+        result.items
+    );
+    let diagnostic = common::diagnostic(&yaml, &result.render(common::SNAPSHOT_STYLE).join("\n"));
+    diagnostic.assert_contains(&["D02", "has 1 repeated occurrence (`1.0`; row: 2)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
 }
 
 #[test]
@@ -786,9 +923,9 @@ fn nulls_alongside_a_real_duplicate_report_only_the_duplicate() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D02"),
-                kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+                kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
                 ..
-            }] if columns == &["id"] && rows == &[3]
+            }] if columns == &["id"] && rows == &[3] && sampled(values) == ["1.0"]
         ),
         "got {:?}",
         result.items
@@ -1089,9 +1226,9 @@ fn differently_encoded_decimals_are_duplicates() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D02"),
-                kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+                kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
                 ..
-            }] if columns == &["amount"] && rows == &[2]
+            }] if columns == &["amount"] && rows == &[2] && sampled(values) == ["0.01"]
         ),
         "got {:?}",
         result.items
@@ -1122,9 +1259,11 @@ fn signed_zeros_are_duplicates() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D02"),
-                kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+                kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
                 ..
-            }] if columns == &["score"] && rows == &[2]
+            // Reported as stored: the duplicate is `-0.0`, even though it is
+            // `0.0` that it duplicates.
+            }] if columns == &["score"] && rows == &[2] && sampled(values) == ["-0.0"]
         ),
         "got {:?}",
         result.items
@@ -1159,9 +1298,9 @@ fn float16_unique_column_is_checked() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D02"),
-                kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+                kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
                 ..
-            }] if columns == &["reading"] && rows == &[2]
+            }] if columns == &["reading"] && rows == &[2] && sampled(values) == ["-0"]
         ),
         "got {:?}",
         result.items
@@ -1195,9 +1334,9 @@ fn distinct_nan_bit_patterns_are_duplicates() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D02"),
-                kind: ProblemKind::DuplicateValues { columns, count: 1, rows },
+                kind: ProblemKind::DuplicateValues { columns, count: 1, rows, values, .. },
                 ..
-            }] if columns == &["score"] && rows == &[2]
+            }] if columns == &["score"] && rows == &[2] && sampled(values) == ["NaN"]
         ),
         "got {:?}",
         result.items
@@ -1315,12 +1454,12 @@ fn foreign_key_orphan_value_reported() {
             result.items.as_slice(),
             [Problem {
                 code: Some("D05"),
-                kind: ProblemKind::ForeignKeyNotFound { column, references, count: 1, rows, values },
+                kind: ProblemKind::ForeignKeyNotFound { column, references, count: 1, rows, values, .. },
                 ..
             }] if column == "category_id"
                 && references == "category.id"
                 && rows == &[3]
-                && values == &["5"]
+                && sampled(values) == ["5"]
         ),
         "got {:?}",
         result.items
@@ -1330,6 +1469,46 @@ fn foreign_key_orphan_value_reported() {
         &yaml,
         &result.render(common::SNAPSHOT_STYLE).join("\n")
     ));
+}
+
+/// `values` line up with `rows` one for one, so an orphan repeated across rows
+/// is reported once per row.
+#[test]
+fn every_orphan_row_reports_its_value() {
+    let yaml = build_fk(
+        "REQUIRED INT64 category_id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[5, 1, 5], None, None)
+                .unwrap();
+        },
+        "REQUIRED INT64 id",
+        |col| {
+            col.typed::<Int64Type>()
+                .write_batch(&[1, 2, 3], None, None)
+                .unwrap();
+        },
+        "number(id)",
+        "[1, 2]",
+    );
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D05"),
+                kind: ProblemKind::ForeignKeyNotFound { count: 2, rows, values, .. },
+                ..
+            }] if rows == &[1, 3] && sampled(values) == ["5", "5"]
+        ),
+        "got {:?}",
+        result.items
+    );
+    let diagnostic = common::diagnostic(&yaml, &result.render(common::SNAPSHOT_STYLE).join("\n"));
+    diagnostic.assert_contains(&["D05", "(`5`; rows: 1, 3)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
 }
 
 /// A restricted foreign key's orphan values are withheld from both the
@@ -1449,7 +1628,7 @@ fn foreign_key_null_values_are_exempt() {
                 code: Some("D05"),
                 kind: ProblemKind::ForeignKeyNotFound { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[3] && values == &["5"]
+            }] if rows == &[3] && sampled(values) == ["5"]
         ),
         "got {:?}",
         result.items
@@ -1474,7 +1653,7 @@ fn foreign_key_string_orphan_reported() {
                 code: Some("D05"),
                 kind: ProblemKind::ForeignKeyNotFound { references, count: 1, rows, values, .. },
                 ..
-            }] if references == "category.id" && rows == &[3] && values == &["z"]
+            }] if references == "category.id" && rows == &[3] && sampled(values) == ["z"]
         ),
         "got {:?}",
         result.items
@@ -1542,7 +1721,7 @@ fn foreign_key_across_decimal_encodings() {
                 code: Some("D05"),
                 kind: ProblemKind::ForeignKeyNotFound { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[2] && values == &["9.99"]
+            }] if rows == &[2] && sampled(values) == ["9.99"]
         ),
         "got {:?}",
         result.items
@@ -1606,7 +1785,7 @@ fn foreign_key_without_common_form_reports_all() {
                 code: Some("D05"),
                 kind: ProblemKind::ForeignKeyNotFound { count: 2, rows, values, .. },
                 ..
-            }] if rows == &[1, 3] && values == &["a", "b"]
+            }] if rows == &[1, 3] && sampled(values) == ["a", "b"]
         ),
         "got {:?}",
         result.items
@@ -1669,7 +1848,7 @@ fn foreign_key_date_orphan_renders_as_date() {
                 code: Some("D05"),
                 kind: ProblemKind::ForeignKeyNotFound { count: 1, rows, values, .. },
                 ..
-            }] if rows == &[2] && values == &["2024-01-02"]
+            }] if rows == &[2] && sampled(values) == ["2024-01-02"]
         ),
         "got {:?}",
         result.items
@@ -1805,8 +1984,8 @@ fn list_enum_membership_checked() {
     assert!(
         result.items.iter().any(|p| matches!(
             &p.kind,
-            ProblemKind::ValuesOutsideEnum { count: 1, rows, values }
-                if rows == &vec![2] && values == &vec!["zz".to_string()]
+            ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. }
+                if rows == &vec![2] && sampled(values) == ["zz"]
         )),
         "got {:?}",
         result.items
@@ -1841,8 +2020,8 @@ fn struct_enum_field_membership_checked() {
     assert!(
         result.items.iter().any(|p| matches!(
             &p.kind,
-            ProblemKind::ValuesOutsideEnum { count: 1, rows, values }
-                if rows == &vec![2] && values == &vec!["XX".to_string()]
+            ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. }
+                if rows == &vec![2] && sampled(values) == ["XX"]
         )),
         "got {:?}",
         result.items
@@ -1910,8 +2089,8 @@ fn nested_list_checks_compose() {
     assert!(
         result.items.iter().any(|p| matches!(
             &p.kind,
-            ProblemKind::ValuesOutsideEnum { count: 1, rows, values }
-                if rows == &vec![2] && values == &vec!["zz".to_string()]
+            ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. }
+                if rows == &vec![2] && sampled(values) == ["zz"]
         )),
         "got {:?}",
         result.items
@@ -1990,8 +2169,8 @@ fn deep_alternating_nesting_checks_values() {
     assert!(
         result.items.iter().any(|p| matches!(
             &p.kind,
-            ProblemKind::ValuesOutsideEnum { count: 1, rows, values }
-                if rows == &vec![2] && values == &vec!["bogus".to_string()]
+            ProblemKind::ValuesOutsideEnum { count: 1, rows, values, .. }
+                if rows == &vec![2] && sampled(values) == ["bogus"]
         )),
         "got {:?}",
         result.items
@@ -2010,6 +2189,17 @@ fn deep_alternating_nesting_checks_values() {
 
 /// A two-column table of integers, with `constraints` spliced in at table level.
 fn build_asserted(a: &[i64], b: &[Option<i64>], constraints: &str) -> PathBuf {
+    build_asserted_with_display(a, b, constraints, "")
+}
+
+/// [`build_asserted`], with `display` spliced into column `a`'s entry so an
+/// assertion can read a restricted column.
+fn build_asserted_with_display(
+    a: &[i64],
+    b: &[Option<i64>],
+    constraints: &str,
+    display: &str,
+) -> PathBuf {
     let dir = temp_dir();
     let parquet = dir.join("data.parquet");
     let schema = Arc::new(
@@ -2049,7 +2239,7 @@ fn build_asserted(a: &[i64], b: &[Option<i64>], constraints: &str) -> PathBuf {
                 columns:
                   - name: a
                     type: number(quantity)
-                    range: [-1000000, 1000000]
+                    range: [-1000000, 1000000]{display}
                   - name: b
                     type: number(quantity)
                     range: [-1000000, 1000000]
@@ -2115,6 +2305,66 @@ fn assertion_violated_reports_the_rows() {
     diagnostic.assert_contains(&["D07", "is false for 2 rows", "2, 4"]);
     #[cfg(unix)]
     assert_snapshot!(diagnostic);
+}
+
+/// An assertion reads its columns' values to report a violation, so a
+/// restricted column withholds them there too.
+#[test]
+fn assertion_values_withheld_when_restricted() {
+    let yaml = build_asserted_with_display(
+        &[1, -2, 3],
+        &[None, None, None],
+        &assertion("a > 0"),
+        "\n        display: restricted",
+    );
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D07"),
+                kind: ProblemKind::AssertionViolated { count: 1, rows, values, redacted: true, .. },
+                ..
+            }] if rows == &[2] && values.is_empty()
+        ),
+        "got {:?}",
+        result.items
+    );
+    let diagnostic = common::diagnostic(&yaml, &result.render(common::SNAPSHOT_STYLE).join("\n"));
+    diagnostic.assert_contains(&["D07", "is false for 1 row: 2 (values restricted)"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+/// A restricted column an assertion reads drops out of the values, while the
+/// columns beside it still report theirs.
+#[test]
+fn assertion_withholds_only_its_restricted_column() {
+    let yaml = build_asserted_with_display(
+        &[1, -2, 3],
+        &[Some(10), Some(20), Some(30)],
+        &assertion("a > 0 OR b > 100"),
+        "\n        display: restricted",
+    );
+    let result = validate_data(&yaml, None);
+
+    assert!(
+        matches!(
+            result.items.as_slice(),
+            [Problem {
+                code: Some("D07"),
+                kind: ProblemKind::AssertionViolated { count: 1, rows, values, redacted: true, .. },
+                ..
+            }] if rows == &[2] && sampled(values) == ["20"]
+        ),
+        "got {:?}",
+        result.items
+    );
+    let rendered = result.render(common::SNAPSHOT_STYLE).join("\n");
+    assert!(!rendered.contains("a=-2"), "got {rendered}");
+    #[cfg(unix)]
+    assert_snapshot!(common::diagnostic(&yaml, &rendered));
 }
 
 #[test]


### PR DESCRIPTION
Mostly straightforward. Values are only stored for duplicates, so no cost if no violating rows.

Closes #227.