### PR TITLE
Rename the default expression language to sql

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ The repo contains:
 
 ## Spec and implementation must stay in sync
 
-The spec (`site/spec.md` + validation details in `site/validation.md`) and the implementation (the crates + `schema.yaml`) are two views of the same thing and must never drift apart.
+The spec (`site/spec.md` + validation details in `site/dev-validation.md`) and the implementation (the crates + `schema.yaml`) are two views of the same thing and must never drift apart.
 
 - **New features start in the spec, and REQUIRE human sign-off.** This is the single most important rule in this file. Any new feature is a two-phase process with a hard stop between the phases:
     1. **Write the spec.** Draft and iterate the change in `site/spec.md` *only*. Do not touch `schema.yaml`, the crates, the tests, or any other file in this phase.
@@ -64,7 +64,7 @@ Rust workspace with three crates:
 
 ### Validation levels
 
-The three levels and every check code (`S##` / `M##` / `D##`) are defined in `site/validation.md` — the single source of truth. Don't re-document the checks here or in code comments; point to that file. Each level implies the ones before it.
+The three levels and every check code (`S##` / `M##` / `D##`) are defined in `site/dev-validation.md` — the single source of truth. Don't re-document the checks here or in code comments; point to that file. Each level implies the ones before it.
 
 Implementation, one module per level (entry points re-exported at the crate root):
 
@@ -118,6 +118,7 @@ Any new feature that moves data values toward the user — a new profile statist
 ## Data format
 
 - Keys in `data-dict.yaml` use snake_case (e.g. `primary_key`, `foreign_key`, `$learn_more`).
+- The `language` key names the expression language: `sql` (the default), `r`, or `python`. The translation target that prints the language's own spelling is `SQL(data-dict)`, a dialect of the `SQL` family alongside `ANSI`/`duckdb`/`postgres`.
 
 ## Prose
 

--- a/crates/data-dict-cli/src/main.rs
+++ b/crates/data-dict-cli/src/main.rs
@@ -90,7 +90,7 @@ enum Command {
     /// Translate a dictionary's assertions into R, Python, or SQL
     ///
     /// `--from` reads the other way, taking an expression written in another
-    /// language; `--target data-dict` prints the data-dict spelling of one.
+    /// language; `--target SQL(data-dict)` prints the data-dict spelling of one.
     ///
     /// Writes JSON to stdout: one record per expression, carrying the columns
     /// it reads and one entry per target. The code is a bare predicate for you
@@ -480,7 +480,7 @@ struct TranslateArgs {
     #[arg(long)]
     expr: Option<String>,
     /// The language `--expr` is written in, as a bare family name
-    /// [default: data-dict]
+    /// [default: sql]
     ///
     /// Applies to `--expr` alone: a dictionary's assertions each say what
     /// language they are written in, and no flag overrides that.

--- a/crates/data-dict-cli/tests/cli.rs
+++ b/crates/data-dict-cli/tests/cli.rs
@@ -833,8 +833,8 @@ fn translate(args: &[&str]) -> std::process::Output {
         .expect("failed to run data-dict")
 }
 
-/// `--from` reads the expression, and `--target data-dict` prints the language's
-/// own spelling of it — the round trip the spec describes.
+/// `--from` reads the expression, and `--target SQL(data-dict)` prints the
+/// language's own spelling of it — the round trip the spec describes.
 #[test]
 fn translate_from_r_to_the_language() {
     let output = translate(&[
@@ -843,7 +843,7 @@ fn translate_from_r_to_the_language() {
         "--expr",
         "nchar(postcode) <= 10",
         "--target",
-        "data-dict",
+        "SQL(data-dict)",
         "--pretty",
     ]);
     assert!(output.status.success());
@@ -867,7 +867,7 @@ fn translate_from_an_unknown_language() {
     assert!(!output.status.success());
     let stderr = String::from_utf8(output.stderr).expect("stderr is not valid UTF-8");
     assert!(stderr.contains("unknown expression language"), "{stderr}");
-    assert!(stderr.contains("data-dict, r"), "{stderr}");
+    assert!(stderr.contains("sql, r"), "{stderr}");
 }
 
 /// R that says something the language can't names the construct and says the

--- a/crates/data-dict-cli/tests/snapshots/cli__translate_from_r_to_the_language.snap
+++ b/crates/data-dict-cli/tests/snapshots/cli__translate_from_r_to_the_language.snap
@@ -18,7 +18,7 @@ expression: stdout
     ],
     "translations": [
       {
-        "target": "data-dict",
+        "target": "SQL(data-dict)",
         "code": "LENGTH(postcode) <= 10",
         "notes": []
       }

--- a/crates/data-dict/src/emit/canonical.rs
+++ b/crates/data-dict/src/emit/canonical.rs
@@ -1,4 +1,4 @@
-//! `data-dict` — the language writing itself back out.
+//! `SQL(data-dict)` — the language writing itself back out.
 //!
 //! The one target that is not a foreign language, and so the one that never
 //! diverges: every construct has itself as its spelling. It exists because an
@@ -26,7 +26,7 @@ pub struct Canonical;
 
 impl Target for Canonical {
     fn name(&self) -> &'static str {
-        "data-dict"
+        "SQL(data-dict)"
     }
 
     fn prec(&self, e: &TypedExpr) -> u8 {

--- a/crates/data-dict/src/model.rs
+++ b/crates/data-dict/src/model.rs
@@ -142,7 +142,7 @@ pub enum Language {
 impl Language {
     pub fn as_str(self) -> &'static str {
         match self {
-            Language::DataDict => "data-dict",
+            Language::DataDict => "sql",
             Language::R => "r",
             Language::Python => "python",
         }
@@ -159,7 +159,7 @@ impl Language {
 
     pub fn from_name(name: &str) -> Option<Language> {
         match name {
-            "data-dict" => Some(Language::DataDict),
+            "sql" => Some(Language::DataDict),
             "r" => Some(Language::R),
             "python" => Some(Language::Python),
             _ => None,

--- a/crates/data-dict/src/parse/mod.rs
+++ b/crates/data-dict/src/parse/mod.rs
@@ -104,7 +104,7 @@ impl Language {
 pub fn languages() -> &'static [Language] {
     &[
         Language {
-            name: "data-dict",
+            name: "sql",
             read: |source| AssertExpr::parse(source).map(Parsed::exact),
         },
         Language {
@@ -231,12 +231,12 @@ mod tests {
             panic!("no such language")
         };
         assert!(err.contains("unknown expression language"), "{err}");
-        assert!(err.contains("data-dict, r"), "{err}");
+        assert!(err.contains("sql, r"), "{err}");
     }
 
     #[test]
     fn the_default_is_the_language_itself() {
-        assert_eq!(default_language().name, "data-dict");
+        assert_eq!(default_language().name, "sql");
         // Reading it is just parsing it, so it never has anything to warn about.
         let parsed = default_language().read("qty > 0").expect("parses");
         assert!(parsed.notes.is_empty());

--- a/crates/data-dict/src/report.rs
+++ b/crates/data-dict/src/report.rs
@@ -457,12 +457,12 @@ pub(crate) fn table_assertions(table: &Table) -> Vec<(&crate::model::Assertion, 
         .collect()
 }
 
-/// The check catalogue, as `site/validation.md` documents it.
-const VALIDATION_MD: &str = include_str!("../../../site/validation.md");
+/// The check catalogue, as `site/dev-validation.md` documents it.
+const VALIDATION_MD: &str = include_str!("../../../site/dev-validation.md");
 
 /// What one check is called and how loudly it speaks, so a consumer can name a
 /// code it only ever sees as `D04`. `description` is the full rule as
-/// validation.md's description column states it, markdown included.
+/// dev-validation.md's description column states it, markdown included.
 #[derive(Debug, PartialEq, Eq, serde::Serialize)]
 pub struct Check {
     pub name: &'static str,
@@ -470,7 +470,7 @@ pub struct Check {
     pub description: &'static str,
 }
 
-/// Every check in `site/validation.md`, by code. Read out of that document's
+/// Every check in `site/dev-validation.md`, by code. Read out of that document's
 /// tables rather than kept beside them, so a renamed check can't drift from the
 /// spec that named it.
 pub fn checks() -> BTreeMap<&'static str, Check> {
@@ -755,7 +755,7 @@ mod tests {
             let code = kind.code().expect("a documented kind has a code");
             assert!(
                 checks.contains_key(code),
-                "{code} has no entry in validation.md"
+                "{code} has no entry in dev-validation.md"
             );
         }
     }

--- a/crates/data-dict/src/translate.rs
+++ b/crates/data-dict/src/translate.rs
@@ -24,10 +24,10 @@ use crate::validate_spec::{DefEnv, resolve_definitions};
 
 /// The targets emitted when none is asked for, in a stable order.
 ///
-/// `data-dict` is deliberately absent: it is the language the expression is
-/// already written in, so emitting it by default would repeat the source back
-/// in every translation and in every [export](crate::export) record. Ask for it
-/// by name — see [`all_targets`].
+/// `SQL(data-dict)` is deliberately absent: it is the language the expression
+/// is already written in, so emitting it by default would repeat the source
+/// back in every translation and in every [export](crate::export) record. Ask
+/// for it by name — see [`all_targets`].
 pub(crate) fn registry() -> Vec<Box<dyn Target>> {
     vec![
         Box::new(DuckDb),
@@ -402,16 +402,15 @@ mod tests {
     #[test]
     fn the_language_is_a_target_but_not_a_default_one() {
         // Asking for it by name works...
-        assert!(resolve("data-dict").is_ok());
-        assert!(resolve("DATA-DICT").is_ok(), "matching ignores case");
+        assert!(resolve("sql(data-dict)").is_ok());
+        assert!(resolve("SQL(DATA-DICT)").is_ok(), "matching ignores case");
         // ...but it is left out of the set emitted when none is named, so a
         // translation never just repeats the expression it was given.
-        assert!(!registry().iter().any(|t| t.name() == "data-dict"));
-        // It has no dialects, so no family default points at it.
-        assert!(
-            !FAMILY_DEFAULTS
-                .iter()
-                .any(|(family, _)| *family == "data-dict")
+        assert!(!registry().iter().any(|t| t.name() == "SQL(data-dict)"));
+        // Its family's default is ANSI, so a bare `sql` doesn't mean it.
+        assert_eq!(
+            FAMILY_DEFAULTS.iter().find(|(family, _)| *family == "sql"),
+            Some(&("sql", "SQL(ANSI)"))
         );
     }
 }

--- a/crates/data-dict/tests/snapshots/translate__an_r_expression_reports_its_language_and_canonical_form.snap
+++ b/crates/data-dict/tests/snapshots/translate__an_r_expression_reports_its_language_and_canonical_form.snap
@@ -18,7 +18,7 @@ expression: "serde_json::to_string_pretty(&translations).unwrap()"
     ],
     "translations": [
       {
-        "target": "data-dict",
+        "target": "SQL(data-dict)",
         "code": "LENGTH(postcode) <= 10",
         "notes": []
       }

--- a/crates/data-dict/tests/snapshots/validate_spec__an_unknown_language_is_rejected_structurally.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__an_unknown_language_is_rejected_structurally.snap
@@ -18,6 +18,6 @@ error[Q-1-12]: A value must be one of its schema's allowed values.
   --> dict.yaml:12:19
    |
 LL |         language: perl
-   |                   ^^^^ Value must be one of: "data-dict", "r", "python", got '"perl"'
+   |                   ^^^^ Value must be one of: "sql", "r", "python", got '"perl"'
    |
    = help: Check the schema for allowed values?

--- a/crates/data-dict/tests/translate.rs
+++ b/crates/data-dict/tests/translate.rs
@@ -62,7 +62,7 @@ fn an_r_expression_reports_its_language_and_canonical_form() {
     let options = Options {
         expr: Some("nchar(postcode) <= 10".to_string()),
         from: Some("r".to_string()),
-        targets: vec!["data-dict".to_string()],
+        targets: vec!["SQL(data-dict)".to_string()],
         ..Options::default()
     };
     let translations = translate(&path, &options).expect("translates");
@@ -94,7 +94,7 @@ fn the_language_is_not_among_the_default_targets() {
         .iter()
         .map(|t| t.target)
         .collect();
-    assert!(!targets.contains(&"data-dict"), "{targets:?}");
+    assert!(!targets.contains(&"SQL(data-dict)"), "{targets:?}");
     // And a record that needed no reading carries neither language nor
     // canonical form: the expression is already in the language.
     assert!(translations[0].language.is_none());
@@ -130,7 +130,7 @@ fn reading_from_another_language_adds_the_language_to_the_defaults() {
         .iter()
         .map(|t| t.target)
         .collect();
-    assert!(targets.contains(&"data-dict"), "{targets:?}");
+    assert!(targets.contains(&"SQL(data-dict)"), "{targets:?}");
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn an_unknown_source_language_lists_the_readable_ones() {
         rendered.contains("unknown expression language"),
         "{rendered}"
     );
-    assert!(rendered.contains("data-dict, r"), "{rendered}");
+    assert!(rendered.contains("sql, r"), "{rendered}");
 }
 
 /// R that is well-formed but says something the language can't says which

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -3057,7 +3057,7 @@ fn the_language_key_may_name_the_default_explicitly() {
         )
     };
     assert_clean_dict(&body(""));
-    assert_clean_dict(&body("\n        language: data-dict"));
+    assert_clean_dict(&body("\n        language: sql"));
 }
 
 /// One reader takes all three R dialects, so nothing has to say which is meant.

--- a/schema.yaml
+++ b/schema.yaml
@@ -133,7 +133,7 @@ object:
                                 # semantic: lowering never has to carry an
                                 # expression in a language it can't parse.
                                 language:
-                                  enum: [data-dict, r, python]
+                                  enum: [sql, r, python]
                                 description: string
                     examples:
                       arrayOf: any
@@ -154,7 +154,7 @@ object:
                     assert: string
                     # See the column-level `constraints` above.
                     language:
-                      enum: [data-dict, r, python]
+                      enum: [sql, r, python]
                     description: string
 
             # Named expressions (metrics, filters, derived values). Name
@@ -177,7 +177,7 @@ object:
                     # The language `expr` is written in; see the column-level
                     # `constraints` above.
                     language:
-                      enum: [data-dict, r, python]
+                      enum: [sql, r, python]
                     label: string
                     description: string
                     details: string

--- a/site/dev-validation.md
+++ b/site/dev-validation.md
@@ -36,7 +36,7 @@ Their codes are the `S60` block, reserved for structural checks:
 |------|------|-----|-------------|
 | S60 | Missing required key | E | A mapping is missing a key the spec requires, such as a table without `columns`. |
 | S61 | Wrong value type | E | A value's type is not one the spec allows there, such as a `description` given a list instead of a string. |
-| S62 | Value not allowed | E | A value is not among the fixed set the spec allows there, such as a `display` other than `restricted`, or a [`language`](validate.md#expression-languages) other than `data-dict`, `r` or `python`. |
+| S62 | Value not allowed | E | A value is not among the fixed set the spec allows there, such as a `display` other than `restricted`, or a [`language`](validate.md#expression-languages) other than `sql`, `r` or `python`. |
 | S63 | Empty mapping | E | A mapping the spec requires at least one entry in is empty, such as a table with no columns. |
 | S64 | Unknown key | E | A mapping contains a key the spec doesn't define. A misspelled key reports this rather than the `S60` for the key it was meant to be, and the two are reported together when both apply. |
 | S65 | Duplicate key | E | The same key appears twice in one mapping. |

--- a/site/expression-execution.md
+++ b/site/expression-execution.md
@@ -71,13 +71,13 @@ A target is named `family(dialect)`. A bare family name means that family's defa
 |--------|--------------------------------|-----------------|
 | `R` | `base`, `tidyverse`, `data.table` | `R(base)` |
 | `Python` | `polars`, `pandas` | `Python(polars)` |
-| `SQL` | `ANSI`, `duckdb`, `postgres` | `SQL(ANSI)` |
+| `SQL` | `data-dict`, `ANSI`, `duckdb`, `postgres` | `SQL(ANSI)` |
 
 : {tbl-colwidths="[15,45,40]"}
 
-Seven of the eight targets are defined by something outside this specification: `R(tidyverse)` means what dplyr and stringr do, `Python(polars)` what polars does, `SQL(duckdb)` what DuckDB does. Those are versioned, testable things, and the translation for each is fixed by agreement with the reference implementation rather than by wording here.
+Seven of the nine targets are defined by something outside this specification: `R(tidyverse)` means what dplyr and stringr do, `Python(polars)` what polars does, `SQL(duckdb)` what DuckDB does. Those are versioned, testable things, and the translation for each is fixed by agreement with the reference implementation rather than by wording here.
 
-`SQL(ANSI)` is the exception, and [has a grammar of its own](#ansi) — there is no "ANSI engine" to define it.
+The exceptions are `SQL(data-dict)`, which is the language itself as [Expressions](expressions.md) defines it, and `SQL(ANSI)`, which [has a grammar of its own](#ansi) — there is no "ANSI engine" to define it.
 
 ### Sources
 
@@ -87,7 +87,7 @@ A source is named by family alone, where a target is named `family(dialect)`. Th
 
 | Family | Written | Reads |
 |--------|---------|-------|
-| data-dict | `data-dict` | the language itself |
+| SQL | `sql` | the `SQL(data-dict)` spelling — the language itself |
 | R | `r` | every spelling the three `R(...)` targets emit |
 | Python | `python` | the polars expression style `Python(polars)` emits |
 
@@ -95,7 +95,7 @@ A source is named by family alone, where a target is named `family(dialect)`. Th
 
 Each surface is exactly what that family's targets emit, and no more. That is a deliberate bound: it makes the surface a finite, testable list rather than "R", and it makes the round trip a property that can be checked — every expression this specification can emit as R must read back as itself.
 
-`data-dict` is a target as well as a source. It has no dialects, so it is written bare. It is left out of the targets emitted by default, since an expression already written in the language has nothing to gain from being printed back — but reading from another language is exactly the case where the data-dict spelling is the interesting one, so `--from` puts it back in. `--target data-dict` asks for it outright.
+`SQL(data-dict)` is a target as well as a source. It is left out of the targets emitted by default, since an expression already written in the language has nothing to gain from being printed back — but reading from another language is exactly the case where the data-dict spelling is the interesting one, so `--from` puts it back in. `--target SQL(data-dict)` asks for it outright.
 
 #### What a round trip normalises
 

--- a/site/spec.md
+++ b/site/spec.md
@@ -339,7 +339,7 @@ Each entry is a map with:
 
 * `name` (required): the definition's name. Must be non-empty and unique within the table. Definitions and columns share a namespace: a definition's name must not match any column name in the same table.
 * `expr` (required): an expression in the [expression language](expressions.md), or [written in another language](validate.md#expression-languages) and read into it. Unlike an assertion, it need not be boolean.
-* `language`: the language `expr` is written in; see [Expression languages](validate.md#expression-languages). Omitted, it is data-dict's own.
+* `language`: the language `expr` is written in; see [Expression languages](validate.md#expression-languages). Omitted, it is `sql`.
 * `label`, `description`, `details`: human-readable documentation for the definition; see [Name, label, description & details](#name-label-description--details).
 * `todo`: a note of work that remains before the definition is complete; see [Todo](#todo).
 

--- a/site/validate.md
+++ b/site/validate.md
@@ -76,7 +76,7 @@ Assertions are evaluated row-by-row, using SQL's three-valued logic, so an expre
 
 Expressions can be written in one of three languages:
 
-* **`data-dict`** (the default): a SQL-like language.
+* **`sql`** (the default): a SQL-like language.
 * **`r`**: an R-like language with support for base and tidyverse function names.
 * **`python`**: a Python-like language supporting [Polars](https://pola.rs) expression style.
 
@@ -101,7 +101,7 @@ The following sections describe the supported operations, but our hope is that y
 
 ### Arithmetic, comparison, and logic
 
-Arithmetic (`+`, `-`, `*`, `/`) is spelled the same in all three languages. Equality is `=` in data-dict but `==` in R and Python; `!=` works everywhere, and data-dict also accepts `<>`. `AND`, `OR`, and `NOT` become `&`, `|`, and `!` in R, and `&`, `|`, and `~` in Python — where `&` and `|` bind tighter than comparisons, so each comparison needs parentheses.
+Arithmetic (`+`, `-`, `*`, `/`) is spelled the same in all three languages. Equality is `=` in SQL but `==` in R and Python; `!=` works everywhere, and SQL also accepts `<>`. `AND`, `OR`, and `NOT` become `&`, `|`, and `!` in R, and `&`, `|`, and `~` in Python — where `&` and `|` bind tighter than comparisons, so each comparison needs parentheses.
 
 ```yaml
 constraints:
@@ -209,7 +209,7 @@ However it's written, the predicate is evaluated once per selected column and th
 
 Every function has a variant in each of the three languages. 
 
-| data-dict | R | Python |
+| SQL | R | Python |
 |-----------|---|--------|
 | `LENGTH(s)` | `nchar(s)`, `str_length(s)` | `.str.len_chars()` |
 | `LOWER(s)` | `tolower(s)`, `str_to_lower(s)` | `.str.to_lowercase()` |


### PR DESCRIPTION
Hard rename of the default expression language from `data-dict` to `sql`:

- `language: data-dict` is no longer accepted; the schema enum is `[sql, r, python]` (S62 rejects the old value, no alias).
- The translation target that prints the language's own spelling becomes a dialect of the SQL family: `--target SQL(data-dict)`. Bare `sql` still means `SQL(ANSI)`.
- Spec docs updated: `validate.md`, `spec.md`, `dev-validation.md`, `expression-execution.md`.

Also fixes a pre-existing build break: `report.rs` still included `site/validation.md` after that file was renamed to `dev-validation.md`.

## Test plan

- `cargo test --workspace` passes; three insta snapshots updated (target name, S62 enum message).
- `cargo fmt` / `cargo clippy --workspace --all-targets` clean (only pre-existing `result_large_err` warnings).
- All `site/examples/*.yaml` and the playground dictionary still validate.