### PR TITLE
Add top-level language key for a dictionary-wide default expression language

### DIFF
--- a/crates/data-dict/src/export.rs
+++ b/crates/data-dict/src/export.rs
@@ -22,8 +22,8 @@ use data_dict_parquet::{
 use crate::assert_expr::{self, ColumnsSelector, DefType, Expr, ExprKind, Ty};
 use crate::emit;
 use crate::model::{
-    Assertion, Cardinality, Column, Constraint, DataDict, Definition, Relationship, Representation,
-    Scalar, Spanned, Table, Version,
+    Assertion, Cardinality, Column, Constraint, DataDict, Definition, Language, Relationship,
+    Representation, Scalar, Spanned, Table, Version,
 };
 use crate::problem::{ProblemKind, ProblemSet, Severity};
 use crate::validate_spec::{DefEnv, resolve_definitions};
@@ -638,12 +638,12 @@ fn build_table(
         constraints: table
             .constraints
             .iter()
-            .map(|a| build_assertion(a, table, &defs))
+            .map(|a| build_assertion(a, table, &defs, dict.language()))
             .collect(),
         definitions: table
             .definitions
             .iter()
-            .map(|d| build_definition(d, table, &defs))
+            .map(|d| build_definition(d, table, &defs, dict.language()))
             .collect(),
     }
 }
@@ -767,7 +767,7 @@ fn build_column(
         assertions: col
             .assertions
             .iter()
-            .map(|a| build_assertion(a, table, defs))
+            .map(|a| build_assertion(a, table, defs, dict.language()))
             .collect(),
         profile,
     }
@@ -777,6 +777,7 @@ fn build_definition(
     def: &Definition,
     table: &Table,
     defs: &HashMap<String, DefType>,
+    default_language: Language,
 ) -> ExportDefinition {
     let mut columns = Vec::new();
     let mut definitions = Vec::new();
@@ -806,7 +807,13 @@ fn build_definition(
         Ty::Interval => Some("interval"),
         Ty::Struct | Ty::List | Ty::Any | Ty::Unknown => None,
     });
-    let reading = reading(def.language(), def.expr.as_ref(), table, defs, &def.notes);
+    let reading = reading(
+        def.language(default_language),
+        def.expr.as_ref(),
+        table,
+        defs,
+        &def.notes,
+    );
     ExportDefinition {
         name: def.name.value.clone(),
         label: def.label.clone(),
@@ -871,6 +878,7 @@ fn build_assertion(
     assertion: &Assertion,
     table: &Table,
     defs: &HashMap<String, DefType>,
+    default_language: Language,
 ) -> ExportAssertion {
     let mut columns = Vec::new();
     let mut definitions = Vec::new();
@@ -880,7 +888,7 @@ fn build_assertion(
         translations = translate_expression(&expr.root, table, defs);
     }
     let reading = reading(
-        assertion.language(),
+        assertion.language(default_language),
         assertion.expr.as_ref(),
         table,
         defs,

--- a/crates/data-dict/src/lower.rs
+++ b/crates/data-dict/src/lower.rs
@@ -19,12 +19,15 @@ use crate::problem::{Problem, ProblemSet, Severity, subspan};
 /// Lower an AST, collecting any lowering problems (currently only S04
 /// for unparseable join expressions).
 pub fn lower(root: &YamlWithSourceInfo, problems: &mut ProblemSet) -> DataDict {
+    let language = root.as_hash().and_then(lower_language);
+    let default_language = language.as_ref().map_or(Language::DataDict, |l| l.value);
+
     let mut tables = Vec::new();
     if let Some(t_node) = root.get_hash_value("tables")
         && let Some(items) = t_node.as_array()
     {
         for item in items {
-            if let Some(table) = lower_table(item, problems) {
+            if let Some(table) = lower_table(item, default_language, problems) {
                 tables.push(table);
             }
         }
@@ -80,6 +83,7 @@ pub fn lower(root: &YamlWithSourceInfo, problems: &mut ProblemSet) -> DataDict {
         relationships,
         glossary,
         todo,
+        language,
     }
 }
 
@@ -112,7 +116,11 @@ fn lower_todo(value: &YamlWithSourceInfo, value_span: SourceInfo) -> Option<Span
         .map(|s| Spanned::new(s.to_string(), value_span))
 }
 
-fn lower_table(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<Table> {
+fn lower_table(
+    node: &YamlWithSourceInfo,
+    default_language: Language,
+    problems: &mut ProblemSet,
+) -> Option<Table> {
     let entries = node.as_hash()?;
     let name_entry = entries
         .iter()
@@ -126,7 +134,7 @@ fn lower_table(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<T
         && let Some(items) = c_node.as_array()
     {
         for col in items {
-            if let Some(c) = lower_column(col, problems) {
+            if let Some(c) = lower_column(col, default_language, problems) {
                 columns.push(c);
             }
         }
@@ -136,7 +144,7 @@ fn lower_table(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<T
         && let Some(items) = c_node.as_array()
     {
         for item in items {
-            if let Some(a) = lower_assertion(item, problems) {
+            if let Some(a) = lower_assertion(item, default_language, problems) {
                 constraints.push(a);
             }
         }
@@ -146,7 +154,7 @@ fn lower_table(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<T
         && let Some(items) = d_node.as_array()
     {
         for item in items {
-            if let Some(d) = lower_definition(item, problems) {
+            if let Some(d) = lower_definition(item, default_language, problems) {
                 definitions.push(d);
             }
         }
@@ -194,7 +202,11 @@ fn lower_table(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<T
     })
 }
 
-fn lower_column(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<Column> {
+fn lower_column(
+    node: &YamlWithSourceInfo,
+    default_language: Language,
+    problems: &mut ProblemSet,
+) -> Option<Column> {
     let entries = node.as_hash()?;
     let mut name: Option<Spanned<String>> = None;
     let mut label: Option<String> = None;
@@ -274,7 +286,7 @@ fn lower_column(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<
                             if let Some(parsed) = Constraint::parse(s) {
                                 constraints.push(Spanned::new(parsed, c.source_info.clone()));
                             }
-                        } else if let Some(a) = lower_assertion(c, problems) {
+                        } else if let Some(a) = lower_assertion(c, default_language, problems) {
                             // A map with an `assert` key is an assertion.
                             assertions.push(a);
                         }
@@ -285,7 +297,7 @@ fn lower_column(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<
                 if let Some(items) = entry.value.as_array() {
                     let mut fs = Vec::new();
                     for f in items {
-                        if let Some(col) = lower_column(f, problems) {
+                        if let Some(col) = lower_column(f, default_language, problems) {
                             fs.push(col);
                         }
                     }
@@ -322,7 +334,11 @@ fn lower_column(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<
 /// `assert` string) and leaves `expr` as `None`, mirroring the S04 handling of a
 /// bad `join`. Returns `None` only for a node without a string `assert` value,
 /// which the schema rejects upstream.
-fn lower_assertion(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<Assertion> {
+fn lower_assertion(
+    node: &YamlWithSourceInfo,
+    default_language: Language,
+    problems: &mut ProblemSet,
+) -> Option<Assertion> {
     let entries = node.as_hash()?;
     let assert_entry = entries
         .iter()
@@ -337,7 +353,14 @@ fn lower_assertion(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Opti
     let span = assert_entry.value_span.clone();
     let language = lower_language(entries);
 
-    let (expr, notes) = read(text, language.as_ref(), "`assert`", &span, problems);
+    let (expr, notes) = read(
+        text,
+        language.as_ref(),
+        default_language,
+        "`assert`",
+        &span,
+        problems,
+    );
 
     Some(Assertion {
         text: Spanned::new(text.to_string(), span),
@@ -369,11 +392,12 @@ fn lower_language(entries: &[YamlHashEntry]) -> Option<Spanned<Language>> {
 fn read(
     text: &str,
     language: Option<&Spanned<Language>>,
+    default_language: Language,
     what: &str,
     span: &SourceInfo,
     problems: &mut ProblemSet,
 ) -> (Option<AssertExpr>, Vec<&'static str>) {
-    let language = language.map_or(Language::DataDict, |l| l.value);
+    let language = language.map_or(default_language, |l| l.value);
     let parsed = match language {
         Language::DataDict => AssertExpr::parse(text).map(|expr| (expr, Vec::new())),
         Language::R => crate::parse::r::read(text).map(|p| (p.expr, p.notes)),
@@ -423,7 +447,11 @@ fn read(
 /// token within the `expr` string) and leaves `expr` as `None`, mirroring
 /// [`lower_assertion`]. Returns `None` for a node without a string `expr`
 /// value, which the schema rejects upstream.
-fn lower_definition(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Option<Definition> {
+fn lower_definition(
+    node: &YamlWithSourceInfo,
+    default_language: Language,
+    problems: &mut ProblemSet,
+) -> Option<Definition> {
     let entries = node.as_hash()?;
     let name_entry = entries
         .iter()
@@ -446,7 +474,14 @@ fn lower_definition(node: &YamlWithSourceInfo, problems: &mut ProblemSet) -> Opt
     };
 
     let language = lower_language(entries);
-    let (expr, notes) = read(text, language.as_ref(), "definition", &span, problems);
+    let (expr, notes) = read(
+        text,
+        language.as_ref(),
+        default_language,
+        "definition",
+        &span,
+        problems,
+    );
 
     let todo = entries
         .iter()

--- a/crates/data-dict/src/model.rs
+++ b/crates/data-dict/src/model.rs
@@ -38,6 +38,10 @@ pub struct DataDict {
     pub glossary: Vec<GlossaryEntry>,
     /// The dataset-level `todo`, when present (see S31).
     pub todo: Option<Spanned<String>>,
+    /// The top-level `language`: the default expression language for `assert`
+    /// and definition `expr` expressions that don't name their own. Join
+    /// expressions are always SQL and unaffected.
+    pub language: Option<Spanned<Language>>,
 }
 
 /// The dictionary's own `version`: exactly one of the three kinds (S17).
@@ -57,6 +61,14 @@ pub struct GlossaryEntry {
 impl DataDict {
     /// The first table with the given name, or `None`. Duplicate names are an
     /// error (S10); lookups resolve to the first so downstream checks still run.
+    /// The dictionary's default expression language: `sql` unless the
+    /// top-level `language` key says otherwise.
+    pub fn language(&self) -> Language {
+        self.language
+            .as_ref()
+            .map_or(Language::DataDict, |l| l.value)
+    }
+
     pub fn table(&self, name: &str) -> Option<&Table> {
         self.tables.iter().find(|t| t.name.value == name)
     }
@@ -120,11 +132,10 @@ pub struct Assertion {
 }
 
 impl Assertion {
-    /// The language this was written in, defaulting to the dictionary's own.
-    pub fn language(&self) -> Language {
-        self.language
-            .as_ref()
-            .map_or(Language::DataDict, |l| l.value)
+    /// The language this was written in: the author's own `language`, or the
+    /// dictionary default when omitted.
+    pub fn language(&self, default: Language) -> Language {
+        self.language.as_ref().map_or(default, |l| l.value)
     }
 }
 
@@ -186,11 +197,10 @@ pub struct Definition {
 }
 
 impl Definition {
-    /// The language this was written in, defaulting to the dictionary's own.
-    pub fn language(&self) -> Language {
-        self.language
-            .as_ref()
-            .map_or(Language::DataDict, |l| l.value)
+    /// The language this was written in: the author's own `language`, or the
+    /// dictionary default when omitted.
+    pub fn language(&self, default: Language) -> Language {
+        self.language.as_ref().map_or(default, |l| l.value)
     }
 }
 

--- a/crates/data-dict/src/translate.rs
+++ b/crates/data-dict/src/translate.rs
@@ -173,25 +173,31 @@ pub fn translate(path: &Path, options: &Options) -> Result<Vec<Translation>, Pro
         },
     };
 
-    let targets = match options
+    let explicit = match options
         .targets
         .iter()
         .map(|name| resolve(name))
         .collect::<Result<Vec<_>, _>>()
     {
-        Ok(targets) if !targets.is_empty() => targets,
-        // Reading from another language makes the data-dict spelling the
-        // interesting one, so it joins the default set exactly then.
-        Ok(_) if from.name != parse::default_language().name => all_targets(),
-        Ok(_) => registry(),
+        Ok(targets) if !targets.is_empty() => Some(targets),
+        Ok(_) => None,
         Err(message) => {
             problems.push(Problem::preflight(ProblemKind::Spec, message));
             return Err(problems);
         }
     };
+    // Reading from another language makes the data-dict spelling the
+    // interesting one, so it joins the default set exactly then.
+    let default_targets = |foreign: bool| {
+        if foreign { all_targets() } else { registry() }
+    };
 
     match &options.expr {
         Some(source) => {
+            let targets = match explicit {
+                Some(targets) => targets,
+                None => default_targets(from.name != parse::default_language().name),
+            };
             let table = match scope(&dict, options.table.as_deref()) {
                 Ok(table) => table,
                 Err(message) => {
@@ -207,12 +213,31 @@ pub fn translate(path: &Path, options: &Options) -> Result<Vec<Translation>, Pro
                 }
             }
         }
-        None => Ok(translate_assertions(
-            &dict,
-            options.table.as_deref(),
-            &targets,
-        )),
+        None => {
+            let targets = match explicit {
+                Some(targets) => targets,
+                None => default_targets(dict_has_foreign_assertions(&dict)),
+            };
+            Ok(translate_assertions(
+                &dict,
+                options.table.as_deref(),
+                &targets,
+            ))
+        }
     }
+}
+
+/// Whether any assertion was written in a language other than the data-dict
+/// one — its own `language`, or the dictionary's top-level default.
+fn dict_has_foreign_assertions(dict: &DataDict) -> bool {
+    dict.tables
+        .iter()
+        .flat_map(|t| {
+            t.constraints
+                .iter()
+                .chain(t.columns.iter().flat_map(|c| c.assertions.iter()))
+        })
+        .any(|a| a.language(dict.language()) != crate::model::Language::DataDict)
 }
 
 /// The table an ad-hoc expression resolves its columns against: the only one
@@ -309,14 +334,18 @@ fn translate_assertions(
             let Some(ir) = assert_expr::lower(expr, &env) else {
                 continue;
             };
-            out.push(render(
-                &assertion.text.value,
-                expr,
-                table,
-                &defs,
-                &ir,
-                targets,
-            ));
+            let mut translation = render(&assertion.text.value, expr, table, &defs, &ir, targets);
+            // As for an ad-hoc expression: only a foreign language has a
+            // reading to report. The assertion's own `language` wins; omitted,
+            // the dictionary's top-level `language` is where it was read from.
+            let from = assertion.language(dict.language());
+            if from != crate::model::Language::DataDict {
+                translation.language = Some(from.as_str());
+                translation.canonical = emit::emit(&Canonical, &ir).ok().map(|e| e.code);
+                translation.fidelity = (!assertion.notes.is_empty()).then_some("divergent");
+                translation.notes = assertion.notes.clone();
+            }
+            out.push(translation);
         }
     }
     out

--- a/crates/data-dict/tests/snapshots/translate__an_assertion_inheriting_the_dictionarys_language_reports_its_reading.snap
+++ b/crates/data-dict/tests/snapshots/translate__an_assertion_inheriting_the_dictionarys_language_reports_its_reading.snap
@@ -1,0 +1,62 @@
+---
+source: crates/data-dict/tests/translate.rs
+expression: "translate_json(indoc!\n{r#\"\n        language: r\n        description: Each row is a survey response.\n        tables:\n          - name: survey\n            columns:\n              - name: postcode\n                type: string\n                examples: [\"NZ-1010\"]\n            constraints:\n              - assert: nchar(postcode) <= 10\n    \"#})"
+---
+[
+  {
+    "expr": "nchar(postcode) <= 10",
+    "language": "r",
+    "canonical": "LENGTH(postcode) <= 10",
+    "fidelity": "divergent",
+    "notes": [
+      "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+    ],
+    "table": "survey",
+    "type": "boolean",
+    "columns": [
+      "postcode"
+    ],
+    "translations": [
+      {
+        "target": "SQL(duckdb)",
+        "code": "length(\"postcode\") <= 10",
+        "notes": [
+          "DuckDB compares a NaN as equal to itself and greater than every number, where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "R(tidyverse)",
+        "code": "str_length(postcode) <= 10L",
+        "notes": [
+          "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "R(base)",
+        "code": "nchar(postcode) <= 10L",
+        "notes": [
+          "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "R(data.table)",
+        "code": "nchar(postcode) <= 10L",
+        "notes": [
+          "R reads a NaN as missing, so comparing against one gives NA where data-dict answers false; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "Python(polars)",
+        "code": "pl.col(\"postcode\").str.len_chars() <= pl.lit(10)",
+        "notes": [
+          "polars compares a NaN as an ordinary value and makes it equal to itself, where data-dict answers false for every comparison a NaN reaches; a row holding one passes here and is reported there."
+        ]
+      },
+      {
+        "target": "SQL(data-dict)",
+        "code": "LENGTH(postcode) <= 10",
+        "notes": []
+      }
+    ]
+  }
+]

--- a/crates/data-dict/tests/snapshots/validate_spec__an_unknown_top_level_language_is_rejected_structurally.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__an_unknown_top_level_language_is_rejected_structurally.snap
@@ -1,0 +1,20 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+language: perl
+description: Each row is a survey response.
+tables:
+  - name: survey
+    columns:
+      - name: postcode
+        type: string
+────────────────────────────────────────
+error[Q-1-12]: A value must be one of its schema's allowed values.
+  --> dict.yaml:3:11
+   |
+LL | language: perl
+   |           ^^^^ Value must be one of: "sql", "r", "python", got '"perl"'
+   |
+   = help: Check the schema for allowed values?

--- a/crates/data-dict/tests/snapshots/validate_spec__an_unlanguaged_expression_reads_in_the_dictionarys_language.snap
+++ b/crates/data-dict/tests/snapshots/validate_spec__an_unlanguaged_expression_reads_in_the_dictionarys_language.snap
@@ -1,0 +1,21 @@
+---
+source: crates/data-dict/tests/validate_spec.rs
+---
+$version: "0.1.0"
+$learn_more: http://data-dict.tidyverse.org/
+language: r
+description: Each row is a survey response.
+tables:
+  - name: survey
+    columns:
+      - name: postcode
+        type: string
+        examples: ["NZ-1010"]
+    constraints:
+      - assert: postcode IS NOT NULL
+────────────────────────────────────────
+error[S19]: 
+  --> dict.yaml:12:26
+   |
+LL |       - assert: postcode IS NOT NULL
+   |                          ^ `assert` expression does not parse as R: unexpected trailing input

--- a/crates/data-dict/tests/translate.rs
+++ b/crates/data-dict/tests/translate.rs
@@ -189,3 +189,23 @@ fn an_untranslatable_construct_names_itself() {
     assert!(rendered.contains("`sapply()`"), "{rendered}");
     assert!(rendered.contains("no equivalent"), "{rendered}");
 }
+
+/// An assertion that inherits the dictionary's top-level `language` is
+/// reported the same as one that names its own: `language` and `canonical`
+/// appear, and `SQL(data-dict)` joins the default targets because the source
+/// was a foreign language.
+#[test]
+fn an_assertion_inheriting_the_dictionarys_language_reports_its_reading() {
+    insta::assert_snapshot!(translate_json(indoc! {r#"
+        language: r
+        description: Each row is a survey response.
+        tables:
+          - name: survey
+            columns:
+              - name: postcode
+                type: string
+                examples: ["NZ-1010"]
+            constraints:
+              - assert: nchar(postcode) <= 10
+    "#}));
+}

--- a/crates/data-dict/tests/validate_spec.rs
+++ b/crates/data-dict/tests/validate_spec.rs
@@ -3235,3 +3235,85 @@ fn an_unknown_language_is_rejected_structurally() {
     #[cfg(unix)]
     assert_snapshot!(diagnostic);
 }
+
+/// A top-level `language` sets the default for every expression that omits its
+/// own: these R expressions name no language and read as R (with the usual S36
+/// divergence notes an R reading carries).
+#[test]
+fn a_top_level_language_sets_the_default() {
+    assert_valid_dict(indoc! {r#"
+        language: r
+        description: Each row is a survey response.
+        tables:
+          - name: survey
+            columns:
+              - name: postcode
+                type: string
+                examples: ["NZ-1010"]
+                constraints:
+                  - assert: nchar(postcode) <= 10
+            constraints:
+              - assert: nchar(postcode) >= 4
+            definitions:
+              - name: postcode_length
+                expr: nchar(postcode)
+    "#});
+}
+
+/// An expression's own `language` still wins over the dictionary's default.
+#[test]
+fn an_expressions_own_language_overrides_the_default() {
+    assert_clean_dict(indoc! {r#"
+        language: r
+        description: Each row is a survey response.
+        tables:
+          - name: survey
+            columns:
+              - name: postcode
+                type: string
+                examples: ["NZ-1010"]
+            constraints:
+              - assert: postcode IS NOT NULL
+                language: sql
+    "#});
+}
+
+/// An un-languaged expression is read in the dictionary's language, so SQL
+/// under `language: r` fails to parse as R, and the message says which
+/// language it failed as.
+#[test]
+fn an_unlanguaged_expression_reads_in_the_dictionarys_language() {
+    let diagnostic = failing_dict(indoc! {r#"
+        language: r
+        description: Each row is a survey response.
+        tables:
+          - name: survey
+            columns:
+              - name: postcode
+                type: string
+                examples: ["NZ-1010"]
+            constraints:
+              - assert: postcode IS NOT NULL
+    "#});
+    diagnostic.assert_contains(&["S19", "r"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}
+
+/// The top-level `language` is the same closed set as the per-expression key,
+/// held by the schema.
+#[test]
+fn an_unknown_top_level_language_is_rejected_structurally() {
+    let diagnostic = failing_dict(indoc! {r#"
+        language: perl
+        description: Each row is a survey response.
+        tables:
+          - name: survey
+            columns:
+              - name: postcode
+                type: string
+    "#});
+    diagnostic.assert_contains(&["Q-1-12", "language"]);
+    #[cfg(unix)]
+    assert_snapshot!(diagnostic);
+}

--- a/schema.yaml
+++ b/schema.yaml
@@ -41,6 +41,12 @@ object:
     # the dataset. Unenforced: no S-check, never fetched or resolved.
     origin: string
 
+    # The default expression language for `assert` and definition `expr`
+    # expressions that omit their own `language`; itself defaults to `sql`.
+    # Join expressions are always SQL and unaffected.
+    language:
+      enum: [sql, r, python]
+
     # A note of work that remains to be done. Accepted at every describing
     # level (dataset, table, column, field, relationship, definition); each
     # remaining note is reported by S31.

--- a/site/spec.md
+++ b/site/spec.md
@@ -13,6 +13,8 @@ The descriptive keys — `name`, `label`, `description`, and `details` — ident
 
 The dataset may also carry an optional `origin` key: a link to the code that produced it (see [Origin](#origin)). The same key is available on each table.
 
+The top level may also carry an optional `language` key: the default [expression language](validate.md#expression-languages) for the whole dictionary — `sql` (the default), `r`, or `python`. Every `assert` and definition `expr` that omits its own `language` is read in this language; a per-assertion or per-definition `language` overrides it.
+
 Every level of the dictionary — this top level, a table, a column, a struct field, a relationship — may also carry a `todo` key recording work that remains to be done; see [Todo](#todo).
 
 In the common case of a dictionary that describes a single table, these top-level keys should be used to describe the dataset, leaving the table itself undescribed.
@@ -339,7 +341,7 @@ Each entry is a map with:
 
 * `name` (required): the definition's name. Must be non-empty and unique within the table. Definitions and columns share a namespace: a definition's name must not match any column name in the same table.
 * `expr` (required): an expression in the [expression language](expressions.md), or [written in another language](validate.md#expression-languages) and read into it. Unlike an assertion, it need not be boolean.
-* `language`: the language `expr` is written in; see [Expression languages](validate.md#expression-languages). Omitted, it is `sql`.
+* `language`: the language `expr` is written in; see [Expression languages](validate.md#expression-languages). Omitted, it is the dictionary's top-level `language`, itself defaulting to `sql`.
 * `label`, `description`, `details`: human-readable documentation for the definition; see [Name, label, description & details](#name-label-description--details).
 * `todo`: a note of work that remains before the definition is complete; see [Todo](#todo).
 

--- a/site/validate.md
+++ b/site/validate.md
@@ -84,7 +84,7 @@ Note that I say SQL-like, R-like, and Python-like deliberately: there is no SQL/
 
 There are also some subtle differences in how data-dict evaluates expressions compared to the original languages. These are generally minor differences in floating point behavior and unlikely to affect many data analytic results, but are reported as deviations in the output. For example, R's `round` rounds halves to even, but data-dict rounds them away from zero. 
 
-You can override the default by specifying a `language`:
+You can change the default for the whole dictionary with a top-level `language` key, or override it on an individual expression with its own `language`:
 
 ```yaml
 columns:


### PR DESCRIPTION
## Summary

Adds an optional top-level `language` key (`sql` / `r` / `python`, default `sql`) that sets the default expression language for the whole dictionary. Every `assert` and definition `expr` that omits its own `language` is read in this language; a per-expression `language` still overrides. Join expressions are unaffected — they remain their own SQL-specific language.

Spec wording was signed off before implementation, per the repo's spec-first rule.

## Changes

- **Spec**: new top-level `language` paragraph and revised definitions bullet in `site/spec.md`; intro line in `site/validate.md`.
- **`schema.yaml`**: top-level `language` enum, so unknown values are rejected structurally (S62), same as the per-expression key.
- **Model/lowering**: `DataDict` carries the key and exposes the effective default; `Assertion::language()` / `Definition::language()` take the dictionary default; lowering threads it into `read()`.
- **Export**: passes `dict.language()` through to assertion/definition renderings.
- **Translate** (review fix): `translate_assertions` now reports each assertion's effective language — `language`, `canonical`, `fidelity`, and reading notes — matching ad-hoc `--from` expressions, and `SQL(data-dict)` joins the default targets whenever an assertion was read from a foreign language. This gap predated the top-level key (per-assertion `language: r` was also dropped).

## Tests

- New spec tests: default applies, per-expression override wins, SQL under `language: r` fails S19 "does not parse as R", unknown top-level language rejected structurally (with snapshots).
- New translate snapshot test covering the inherited-language record, including `SQL(data-dict)` in the default targets.
- Full workspace suite green; `cargo fmt` / `cargo clippy` clean; all `site/examples/*.yaml` still validate.