### PR TITLE
Add render report UI guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,10 @@ The repo contains:
 - `schema.yaml`: JSON Schema for structural validation of data dictionary files (`schema-field.yaml` holds the recursive struct-field descriptor it references)
 - `dist-workspace.toml`: release config for [`dist`](https://opensource.axo.dev/cargo-dist/). It generates `.github/workflows/release.yml` — never hand-edit that file; change the config and re-run `dist generate`. Install docs live in `site/install.md` and the README.
 
+## Exploration
+
+- When delegating repository discovery or context gathering, prefer a subagent and direct it to use `rg` through bash for file and content discovery; do not use the `search` tool.
+
 ## Code principles
 
 * Reserve comments for explaining why, not what or how. Default to no comment. Before writing one, check it isn't already said by the item's name, its type, its doc comment, or the line below it — if so, drop it.

--- a/crates/data-dict-cli/render/dict/diagram.css
+++ b/crates/data-dict-cli/render/dict/diagram.css
@@ -6,10 +6,10 @@
   --accent2: light-dark(
     color-mix(in oklab, var(--accent2-hue) 80%, black),
     color-mix(in oklab, var(--accent2-hue) 80%, white));
-  --accent2-soft: light-dark(
+  --accent2-fill: light-dark(
     color-mix(in oklab, var(--accent2-hue) 20%, white),
-    color-mix(in oklab, var(--accent2-hue) 20%, var(--background)));
-  --on-accent1: light-dark(#ffffff, #14142c); /* text on an accent1 fill */
+    color-mix(in oklab, var(--accent2-hue) 20%, var(--surface-0)));
+
   --tag-ink: var(--accent2-hue);
   --mark-hue: var(--accent2-hue);
   --mark: color-mix(in oklab, var(--mark-hue) 40%, transparent);
@@ -33,22 +33,22 @@
   /* mixed off the Solarized accents in app.css, towards whatever sits behind */
   --head-bg: light-dark(
     color-mix(in oklab, var(--accent1-hue) 80%, black),
-    color-mix(in oklab, var(--accent1-hue) 40%, var(--background)));
+    color-mix(in oklab, var(--accent1-hue) 40%, var(--surface-0)));
   --head-ink: light-dark(#ffffff, #e7f1ef);
   --demo-head: light-dark(#6b7684, #3a434d);
   --demo-rule: light-dark(#c9c4b8, #454e58);
   /* row touched by the hovered relationship */
   --tint-edge: light-dark(
     color-mix(in oklab, var(--accent1-hue) 20%, white),
-    color-mix(in oklab, var(--accent1-hue) 20%, var(--background)));
+    color-mix(in oklab, var(--accent1-hue) 20%, var(--surface-0)));
   /* row matching the search */
   --tint-search: light-dark(
     color-mix(in oklab, var(--mark-hue) 20%, white),
-    color-mix(in oklab, var(--mark-hue) 20%, var(--background)));
+    color-mix(in oklab, var(--mark-hue) 20%, var(--surface-0)));
   /* the match you selected */
   --tint-search-on: light-dark(
     color-mix(in oklab, var(--mark-hue) 40%, white),
-    color-mix(in oklab, var(--mark-hue) 40%, var(--background)));
+    color-mix(in oklab, var(--mark-hue) 40%, var(--surface-0)));
 }
 
 /* ---- diagram surface ---------------------------------------------------- */
@@ -67,12 +67,12 @@
 #canvas {
   height: min(87.5vh, 775px);
   overflow: auto;
-  background-color: var(--background);
+  background-color: var(--surface-0);
   /* faint dot grid, pinned to the board so it pans with it */
   background-image: radial-gradient(circle at 1px 1px, var(--grid-dot) 1.4px, transparent 0);
   background-size: 24px 24px;
   background-attachment: local;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--line);
   border-radius: 10px;
   box-shadow: inset 0 1px 3px var(--shadow-inset);
   overscroll-behavior: contain;
@@ -104,8 +104,8 @@
   left: 0;
   width: max-content;
   max-width: 340px;
-  background: var(--paper);
-  border: 1px solid var(--rule);
+  background: var(--surface-1);
+  border: 1px solid var(--line);
   border-radius: 7px;
   box-shadow: 0 1px 2px var(--shadow-near), 0 6px 16px -10px var(--shadow-far);
   overflow: hidden;
@@ -153,7 +153,7 @@
   right: 0;
   bottom: 0;
   height: 14px;
-  background: linear-gradient(to top, var(--paper), transparent);
+  background: linear-gradient(to top, var(--surface-1), transparent);
   pointer-events: none;
   transition: opacity 120ms;
 }
@@ -171,17 +171,17 @@
   font-size: var(--row-text);
   white-space: nowrap;
 }
-.row + .row { border-top: 1px solid var(--row-line); }
+.row + .row { border-top: 1px solid var(--line-soft); }
 .row { background: var(--row-bg, transparent); }
 /* primary keys stay put while the rest of the columns scroll under them */
 .row.pinned {
   position: sticky;
   z-index: 1;
-  --row-bg: var(--paper);
+  --row-bg: var(--surface-1);
 }
-.row.pinned.linked { --row-bg: var(--hover-row); }
-.row.pin-last { box-shadow: 0 1px 0 var(--rule), 0 3px 6px -4px var(--shadow-far); }
-.row.linked { --row-bg: var(--hover-row); }
+.row.pinned.linked { --row-bg: var(--accent1-wash); }
+.row.pin-last { box-shadow: 0 1px 0 var(--line), 0 3px 6px -4px var(--shadow-far); }
+.row.linked { --row-bg: var(--accent1-wash); }
 /* the link to this column's entry on its table page */
 .row .name {
   color: var(--ink);
@@ -200,7 +200,7 @@
 .row .key.live:hover { box-shadow: inset 0 0 0 1px currentColor; }
 /* a badge clicked to hold its highlight on */
 .row .key.held {
-  color: var(--on-accent1);
+  color: var(--ink-inverse);
   background: var(--accent1);
   box-shadow: none;
 }
@@ -322,7 +322,7 @@
 /* a table the board is being laid out around */
 .node.picked {
   border-color: var(--accent1);
-  box-shadow: 0 0 0 3px var(--accent1-soft), 0 1px 2px var(--shadow-near),
+  box-shadow: 0 0 0 3px var(--accent1-fill), 0 1px 2px var(--shadow-near),
     0 6px 16px -10px var(--shadow-far);
 }
 
@@ -356,8 +356,8 @@
   font: inherit;
   font-size: var(--text-sm);
   color: var(--ink);
-  background: var(--float);
-  border: 1px solid var(--rule);
+  background: var(--surface-3);
+  border: 1px solid var(--line);
   border-radius: 6px;
   box-shadow: 0 2px 6px -3px var(--shadow-far);
   cursor: pointer;
@@ -367,10 +367,10 @@
 #showall:hover { border-color: var(--accent1); }
 /* nothing has been dragged, so there is nothing to tidy */
 #tidy[disabled] { opacity: 0.45; cursor: default; }
-#tidy[disabled]:hover { border-color: var(--rule); }
+#tidy[disabled]:hover { border-color: var(--line); }
 /* only there while something is off the board */
 #showall[hidden] { display: none; }
-#showall { color: var(--accent1); border-color: var(--accent1-soft); }
+#showall { color: var(--accent1); border-color: var(--accent1-fill); }
 
 #find {
   user-select: text;
@@ -380,8 +380,8 @@
   font: inherit;
   font-size: var(--text-sm);
   color: var(--ink);
-  background: var(--float);
-  border: 1px solid var(--rule);
+  background: var(--surface-3);
+  border: 1px solid var(--line);
   border-radius: 6px;
   box-shadow: 0 2px 6px -3px var(--shadow-far);
 }
@@ -397,8 +397,8 @@
   max-height: 232px;
   overflow-y: auto;
   overflow-x: hidden; /* long names ellipsise instead of scrolling sideways */
-  background: var(--float);
-  border: 1px solid var(--rule);
+  background: var(--surface-3);
+  border: 1px solid var(--line);
   border-radius: 6px;
   box-shadow: 0 10px 26px -14px var(--shadow-lift);
   font-size: var(--text-sm);
@@ -417,15 +417,15 @@
   text-align: left;
   cursor: pointer;
 }
-#hits button + button { border-top: 1px solid var(--row-line); }
+#hits button + button { border-top: 1px solid var(--line-soft); }
 #hits button .hit-path {
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-#hits button:hover { background: var(--hover-row); }
-#hits button[aria-current="true"] { background: var(--accent1-soft); }
+#hits button:hover { background: var(--accent1-wash); }
+#hits button[aria-current="true"] { background: var(--accent1-fill); }
 
 /* Highlighted rows all speak the same language: a background, no border. The
    pinned variants are spelled out so they outrank .row.pinned.linked above, and

--- a/crates/data-dict-cli/render/dict/tables.css
+++ b/crates/data-dict-cli/render/dict/tables.css
@@ -23,8 +23,8 @@ details.xdetails > summary:focus-visible { outline: 2px solid var(--link); outli
 .toolbar { margin-bottom: 14px; }
 .toolbar input[type=search] {
   width: 100%;
-  padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
+  padding: 8px 12px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--surface-1); color: var(--ink); font-size: var(--text-sm);
 }
 
 /* ---- table index ---- */
@@ -109,9 +109,9 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
    lead, the table's header, and the column list. They all share the one
    surface, so the border is what separates them. */
 .lead, .tpage-top, .tpage-list {
-  border: 1px solid var(--rule);
+  border: 1px solid var(--line);
   border-radius: 10px;
-  background: var(--paper);
+  background: var(--surface-1);
 }
 .lead { padding: 14px 16px; margin-bottom: 20px; }
 .lead p { margin: 0 0 16px; max-width: 1000px; color: var(--ink); }
@@ -131,9 +131,9 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .tnav {
   flex: none; width: 232px;
   padding: 12px;
-  border: 1px solid var(--rule);
+  border: 1px solid var(--line);
   border-radius: 10px;
-  background: var(--paper);
+  background: var(--surface-1);
   position: sticky; top: 14px;
   max-height: calc(100vh - 28px);
   display: flex; flex-direction: column; gap: 10px;
@@ -143,8 +143,8 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .tnav-toggle { display: none; }
 .tnav-filter {
   flex: none; min-width: 0; padding: 7px 11px;
-  border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--surface-1); color: var(--ink); font-size: var(--text-sm);
 }
 .tnav-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; margin: 0; padding: 0; list-style: none; }
 .tnav-item {
@@ -156,7 +156,7 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 .tnav-item:hover { background: var(--chip); }
 .tnav-item:focus-visible { outline: 2px solid var(--link); outline-offset: -2px; }
 /* the table being read, wearing the same fill as a held key badge */
-.tnav-item.on { background: var(--accent1); color: var(--on-accent1); font-weight: 650; }
+.tnav-item.on { background: var(--accent1); color: var(--ink-inverse); font-weight: 650; }
 .tnav-none { margin: 0; padding: 4px 8px; color: var(--ink-faint); font-size: var(--text-sm); }
 
 /* The name, its stats and the description on the left; the related-tables box
@@ -175,7 +175,7 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
    gets a short box and several of them share a line. */
 .tpage-related {
   flex: 0 1 auto; max-width: 420px;
-  border-left: 1px solid var(--rule);
+  border-left: 1px solid var(--line);
   padding: 10px 12px;
 }
 .tpage-related[hidden] { display: none; }
@@ -188,17 +188,17 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 
 .tpage-controls { display: flex; gap: 10px; align-items: center; }
 .tpage-sort {
-  flex: none; padding: 8px 30px 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--paper) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6"><path d="M0 0l5 6 5-6z" fill="%237a7a7a"/></svg>') no-repeat right 11px center;
+  flex: none; padding: 8px 30px 8px 12px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--surface-1) url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="10" height="6"><path d="M0 0l5 6 5-6z" fill="%237a7a7a"/></svg>') no-repeat right 11px center;
   color: var(--ink); font-size: var(--text-sm); cursor: pointer;
   -webkit-appearance: none; appearance: none;
 }
 .tpage-filter {
-  flex: 1 1 auto; min-width: 0; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--paper); color: var(--ink); font-size: var(--text-sm);
+  flex: 1 1 auto; min-width: 0; padding: 8px 12px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--surface-1); color: var(--ink); font-size: var(--text-sm);
 }
 
-.col-item { padding: 11px 13px; border-bottom: 1px solid var(--rule); display: flex; gap: 22px; align-items: flex-start; margin: 0 -13px; }
+.col-item { padding: 11px 13px; border-bottom: 1px solid var(--line); display: flex; gap: 22px; align-items: flex-start; margin: 0 -13px; }
 .col-item:last-child { border-bottom: none; }
 /* The permalinked column: "you are here", lifted off the list. */
 .col-item.is-target {
@@ -207,8 +207,8 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
   margin: 7px -21px;
   padding: 16px 21px;
   border-radius: 10px;
-  border: 1px solid var(--rule);
-  background: var(--paper);
+  border: 1px solid var(--line);
+  background: var(--surface-1);
   box-shadow: 0 1px 2px var(--shadow-near), 0 8px 22px -8px var(--shadow-far);
 }
 .col-item:has(+ .is-target) { border-bottom-color: transparent; padding-bottom: 5px }
@@ -221,17 +221,17 @@ abbr.gterm:hover { text-decoration-color: var(--accent1); }
 }
 .modal-overlay[hidden] { display: none; }
 .modal {
-  background: var(--paper); border: 1px solid var(--rule); border-radius: 14px;
+  background: var(--surface-1); border: 1px solid var(--line); border-radius: 14px;
   width: min(760px, 96vw); max-height: 86vh;
   display: flex; flex-direction: column; overflow: hidden;
   box-shadow: 0 24px 60px var(--modal-shadow), 0 0 44px var(--modal-glow);
 }
-.modal-head { flex: none; padding: 18px 22px 14px; border-bottom: 1px solid var(--rule); position: relative; }
+.modal-head { flex: none; padding: 18px 22px 14px; border-bottom: 1px solid var(--line); position: relative; }
 .modal-title-row { display: flex; align-items: center; gap: 10px; }
 .modal-substat { color: var(--ink-soft); font-size: var(--text-sm); margin: 7px 0 13px; }
 .modal-filter {
-  width: 100%; padding: 8px 12px; border: 1px solid var(--rule); border-radius: 8px;
-  background: var(--background); color: var(--ink); font-size: var(--text-sm);
+  width: 100%; padding: 8px 12px; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--surface-0); color: var(--ink); font-size: var(--text-sm);
 }
 .modal-close {
   position: absolute; top: 12px; right: 15px; border: none; background: transparent;
@@ -262,7 +262,7 @@ a.col-name:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; 
 a.col-name .anchor-mark { margin-left: 6px; font-weight: 400; color: var(--ink-soft); opacity: 0; }
 a.col-name:hover .anchor-mark, a.col-name:focus-visible .anchor-mark { opacity: 1; }
 .col-desc { color: var(--ink); font-size: var(--text-sm); margin-top: 4px; line-height: 1.5; }
-.col-meta code { font-family: var(--font-mono); background: var(--paper); border: 1px solid var(--rule); border-radius: 4px; padding: 0 5px; color: var(--ink); }
+.col-meta code { font-family: var(--font-mono); background: var(--surface-1); border: 1px solid var(--line); border-radius: 4px; padding: 0 5px; color: var(--ink); }
 /* a chip cut short for its length: click reveals the whole value, wrapped */
 button.val { font: inherit; }
 .val.cut { cursor: pointer; }
@@ -284,7 +284,7 @@ button.val { font: inherit; }
 /* Join chips share the value chip's shell; what sets them apart is what they
    carry (a wire icon, mono names) and that they act. */
 .join-chip {
-  background: var(--paper); border: 1px solid var(--rule); border-radius: 4px;
+  background: var(--surface-1); border: 1px solid var(--line); border-radius: 4px;
   padding: 0 3px; color: var(--ink);
   display: inline-flex; align-items: center; gap: 5px; font-family: var(--font-mono); cursor: pointer; transition: border-color .1s ease, color .1s ease;
 }
@@ -297,7 +297,7 @@ button.val { font: inherit; }
   margin-top: 2px;
   padding: 9px 10px 8px;
   border-radius: 6px;
-  background: var(--paper);
+  background: var(--surface-1);
 }
 .hist-svg { display: block; }
 .hist-svg .hist-bar { fill: var(--hist-bar); transition: fill .08s ease; shape-rendering: crispEdges;}
@@ -314,7 +314,7 @@ button.val { font: inherit; }
    the right */
 .hist-cap-range { display: flex; justify-content: space-between; gap: 8px; }
 .hist-cap-range .cap-mid { color: var(--ink-faint); }
-.gloss-item { padding: 12px 0; border-bottom: 1px solid var(--rule); }
+.gloss-item { padding: 12px 0; border-bottom: 1px solid var(--line); }
 .gloss-item:last-child { border-bottom: none; }
 .gloss-term { font-weight: 700; font-size: var(--text-base); color: var(--ink); }
 .gloss-def { color: var(--ink); font-size: var(--text-sm); margin-top: 3px; line-height: 1.55; }
@@ -335,7 +335,7 @@ mark { background: var(--mark); color: inherit; border-radius: 2px; padding: 0 1
   color: var(--ink-soft);
 }
 
-.key.fk { color: var(--accent2); background: var(--accent2-soft); }
+.key.fk { color: var(--accent2); background: var(--accent2-fill); }
 
 /* The mark an unresolved `todo` leaves on the thing that carries it. Quiet
    until pointed at: it is a note to whoever is still writing the dictionary,
@@ -350,7 +350,7 @@ mark { background: var(--mark); color: inherit; border-radius: 2px; padding: 0 1
   cursor: help;
 }
 .todo-flag svg { display: block; width: 13px; height: 13px; }
-.todo-flag:hover, .todo-flag:focus-visible { background: var(--warn-soft); }
+.todo-flag:hover, .todo-flag:focus-visible { background: var(--warn-fill); }
 .todo-flag:focus-visible { outline: 2px solid var(--warn); outline-offset: 1px; }
 /* beside the dataset's name it sits against 29px type, and centres on it
    rather than on the baseline the rest of the head shares */

--- a/crates/data-dict-cli/render/report/AGENTS.md
+++ b/crates/data-dict-cli/render/report/AGENTS.md
@@ -1,0 +1,36 @@
+# Render report UI
+
+This directory implements the client-side UI for the self-contained `render-report` HTML page. It uses classic scripts and Preact globals, not ES modules; asset order is defined in `crates/data-dict-cli/src/assets.rs` and is significant.
+
+## Structure
+
+- `report.html` is the page template. It embeds CSS, JavaScript, and JSON payloads.
+- `report.js` owns hash routing, page layout, sidebar navigation, and table/problem/step views.
+- `steps.js` renders the check roster, including filtering, failures-only visibility, sorting, and check verdicts.
+- `rows.js` renders problem and dataset-level row evidence, including highlighted cells and tooltips.
+- `diagnostic.js`, `yaml-excerpt.js`, and `suggestion.js` render problem details and source context.
+- `report.css` contains report-local layout and components. It loads after `render/shared/app.css` and `render/shared/tables.css`, so use shared semantic tokens and primitives rather than duplicating them locally.
+
+## UI behavior
+
+- Routes are `#table/<name>`, `#step/<id>`, and `#problem/<index>`; `#rows/<table>` redirects to the table route.
+- The desktop layout has a sticky table sidebar and a report panel. At narrow widths the sidebar becomes wrapping pills above an edge-to-edge panel.
+- Table verdicts are pass/fail: warnings do not currently create a warning table state.
+- The checks filter matches columns only, not check codes, labels, or messages.
+- Failed check rows link to step details. Unevaluated checks are non-linking.
+
+## Data and safety
+
+The report is a renderer, not a data source: it must not add or reconstruct data. Optional payload fields are commonly absent and must be handled gracefully.
+
+Columns marked `display: restricted` must never reveal data-derived values in rendered HTML, UI controls, tooltips, or diagnostics. Preserve existing upstream redaction behavior; do not infer restricted values from adjacent fields.
+
+Problem-level evidence and dataset-level failed rows have different payload shapes. Count-only findings intentionally use prose rather than a fabricated row table.
+
+## Testing and workflow
+
+There is no browser/UI test suite. Rust tests cover asset composition, generated HTML, offline payload embedding, and redaction in `crates/data-dict-cli/tests/cli.rs`; report JSON contracts and snapshots live in `crates/data-dict/tests/report.rs` and its snapshots.
+
+For manual UI work, `render-report --live` supports CSS hot-swapping. `playground/data-dict.yaml` with `playground/generate.R` provides representative clean and failing data.
+
+The authoritative report payload contract is `site/report.md`; validation and redaction behavior is documented in `site/dev-validation.md`.

--- a/crates/data-dict-cli/render/report/report.css
+++ b/crates/data-dict-cli/render/report/report.css
@@ -18,14 +18,25 @@
   font-weight: 650;
   margin: 0 0 18px;
 }
+/* A count trailing a heading — a table's rows, a card's failures — small and
+   quiet in the page's sans. */
+.row-total {
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: 400;
+  color: var(--ink-faint);
+  margin-left: 10px;
+}
 
 /* ---- The roster of checks ------------------------------------------------
    `.tlist` gives the card, the header row and the numeric alignment. What it
    doesn't give is the right hover: its group-wide highlight suits a four-row
    table block and not a forty-step roster, so the hover moves down to the row. */
 
-.steps tbody.tgroup:hover td { background: transparent; }
-.steps tbody.tgroup tr[data-href]:hover td { background: var(--hover-row); }
+/* `.tlist` tints every row while its group is pointed at; the roster holds its
+   cells still, so pointing changes nothing. The group selector is the one that
+   covers the pointed-at row too. */
+.steps tbody.tgroup:hover td { background: var(--surface-2); }
 .steps th { white-space: nowrap; }
 
 /* The grid the summary and the detail tables share: fixed layout, so every
@@ -41,19 +52,33 @@
 /* The shared table styles pad a heading more than this table pads its cells,
    which would leave every heading short of the column edge its values sit on. */
 .rtable thead th { padding: 6px 10px; }
-.rtable td { overflow: hidden; text-overflow: ellipsis; }
+/* The cells sit on the same lighter surface the failed-rows table draws, with
+   a faint line between rows. */
+.rtable td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--line-soft);
+}
+/* Faint lines between rows and columns alike. The failed-rows table's key/value
+   seam (`.val-start`) is the one stronger column line, and outranks these. */
+.rtable td + td, .rtable th + th,
+.row-table td + td, .row-table th + th { border-left: 1px solid var(--line-soft); }
 
 /* What a step checked: the columns, or the whole table. */
 .step-target { font-family: var(--font-mono); font-size: var(--text-sm); }
 .step-target .whole { color: var(--ink-faint); font-family: var(--font-sans); }
 /* The check's name, with its code quiet in parentheses. */
 .step-check .code { color: var(--ink-faint); font-family: var(--font-mono); font-size: var(--text-sm); }
+/* A failed step's name is the link to its page: the row's own colour, the
+   underline kept. */
+a.step-link { color: inherit; }
 
 /* The two verdicts a problem can carry, as `.key` variants. */
-.key.fail { color: var(--bad); background: var(--bad-soft); }
+.key.fail { color: var(--fail); background: var(--fail-fill); }
 /* A warning severity. It shares yellow with a restricted column but not the
    badge: `restricted` says one particular thing, and a warning is not it. */
-.key.warn { color: var(--warn); background: var(--warn-soft); }
+.key.warn { color: var(--warn); background: var(--warn-fill); }
 
 /* The share of rows a step failed. Geometry from `.missbar`, including the
    min-width that keeps two failures out of ninety thousand visible; the
@@ -61,8 +86,8 @@
 .step-meter { width: 110px; }
 .step-track {
   height: 9px;
-  background: var(--good);
-  border: 0.5px solid var(--rule);
+  background: var(--ok);
+  border: 0.5px solid var(--line);
   box-sizing: border-box;
   position: relative;
   overflow: hidden;
@@ -75,7 +100,7 @@
   bottom: -0.5px;
   min-width: 6px;
   border-radius: 999px 0 0 999px;
-  background: var(--fail-bar);
+  background: var(--fail-mark);
   box-sizing: border-box;
 }
 .step-fill.full { right: -0.5px; min-width: 0; }
@@ -96,27 +121,79 @@
    parent's metrics and sit high beside a mono name. Baseline keeps the square
    on the first line when the name wraps. */
 .sqname { display: inline-flex; align-items: baseline; }
-.verdict-square.pass { background: var(--good); }
+.verdict-square.pass { background: var(--ok); }
 .verdict-square.warn { background: var(--warn); }
-.verdict-square.fail { background: var(--fail-bar); }
+.verdict-square.fail { background: var(--fail-mark); }
 .verdict-square.off { visibility: hidden; }
 
-/* ---- The datasets summary ------------------------------------------------
-   One row per dataset, each row a link to the dataset's detail table. */
+/* ---- The sidebar ----------------------------------------------------------
+   One pill per table, anchored to the window's left edge; the table's page
+   takes the rest, a gap between them. The report breaks out of `main`'s
+   centred column, and the pagehead keeps its own padding. */
 
-/* Every row scrolls to its dataset's section, so every row offers the pointer
-   and the hover. */
-.datasets tbody tr { cursor: pointer; }
-.datasets tbody tr:hover td { background: var(--hover-row); }
-.dataset-name { font-family: var(--font-mono); font-weight: 700; color: var(--accent1); }
+main:has(.report-body) { max-width: none; padding-left: 0; padding-right: 0; }
+main:has(.report-body) .pagehead { padding: 0 28px; }
 
-/* A dataset's detail table, scrolled to from the summary. */
-.dataset-section { scroll-margin-top: 14px; }
-.dataset-section > h3 {
+/* The right padding matches the pagehead's, so the panel's right edge ends
+   where the theme toggle's does. */
+.report-body { display: flex; align-items: flex-start; gap: 16px; padding-right: 28px; }
+/* The table's page sits on the paper surface, framed on all sides now that the
+   sidebar's pills no longer join onto it. */
+.report-main {
+  flex: 1;
+  min-width: 0;
+  background: var(--surface-1);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 24px 28px;
+}
+/* Everything the panel holds — heading rows, cards, table wraps — shares one
+   measure, so the filter row ends where the tables end. */
+.rcontent { max-width: 72em; }
+
+.sidebar {
+  flex: none;
+  width: 220px;
+  position: sticky;
+  top: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 10px 0 10px 10px;
+}
+/* Each table's selector is a pill: bordered on all sides, corners rounded. */
+.sidebar a {
+  display: block;
+  padding: 10px 10px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--ink);
+  text-decoration: none;
+}
+.sidebar a:hover { background: var(--accent1-wash); }
+/* The active pill wears the panel's own surface and shows its border. */
+.sidebar a.active {
+  background: var(--surface-1);
+  border-color: var(--line);
+}
+.sidebar a.active .sqname {font-weight: 700;}
+.sidebar .sqname { max-width: 100%; }
+.sidebar .side-name {
   font-family: var(--font-mono);
-  font-size: var(--text-base);
-  font-weight: 650;
-  margin: 0 0 10px;
+  font-size: var(--text-sm);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+/* The failed against the total rows, set under the name and clearing the
+   verdict square's width (0.57em plus its 0.45em gap). */
+.sidebar .side-count {
+  display: block;
+  margin-left: 1.02em;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--ink-faint);
 }
 
 /* Sortable column heads look like the plain heads they replace. */
@@ -132,11 +209,23 @@
 .rtable th.num .sort-head { flex-direction: row-reverse; }
 .sort-ind.off { visibility: hidden; }
 
-.checks-tools { display: flex; align-items: center; gap: 12px; margin: 0 0 10px; }
+/* The heading and the filters share one row, the filters held to the right. */
+.checks-head { display: flex; align-items: baseline; gap: 12px; margin: 0 0 10px; }
+/* A table hugs its content rather than stretching to the measure; `.rcontent`
+   owns the cap, so the wrap only has to not outrun it. */
+.report-main .tlist-wrap, .row-table { width: fit-content; max-width: 100%; }
+.checks-head h2 { margin: 0; }
+.checks-tools { 
+  display: flex; 
+  align-items: center; 
+  gap: 12px; 
+  margin-left: auto; 
+  margin-right: 10px; /* Match cell padding for better visual alignment */
+}
 .checks-filter {
   padding: 5px 10px;
-  border: 1px solid var(--rule); border-radius: 6px;
-  font: inherit; background: var(--float, #fff); color: var(--ink);
+  border: 1px solid var(--line); border-radius: 6px;
+  font: inherit; background: var(--surface-3, #fff); color: var(--ink);
   min-width: 240px;
 }
 .checks-only {
@@ -149,9 +238,9 @@
    step's summary, a table of failed rows. */
 
 .problem-card, .step-summary {
-  border: 1px solid var(--rule);
+  border: 1px solid var(--line);
   border-radius: 10px;
-  background: var(--paper);
+  background: var(--surface-1);
   padding: 16px 18px;
   margin: 0 0 16px;
 }
@@ -231,9 +320,9 @@ code.tick {
    suggested fix wears the same box, drawn as a diff. */
 
 .yaml-excerpt, .suggestion-diff {
-  border: 1px solid var(--rule);
+  border: 1px solid var(--line);
   border-radius: 8px;
-  background: var(--background);
+  background: var(--surface-0);
   padding: 10px 0;
   margin: 12px 0;
   overflow-x: auto;
@@ -252,18 +341,18 @@ code.tick {
   color: var(--ink-faint);
   user-select: none; /* so copying the snippet yields YAML, not line numbers */
   width: 1%;
-  border-right: 1px solid var(--rule);
+  border-right: 1px solid var(--line);
 }
 .ex-text { color: var(--ink-soft); }
 /* The underline is the faithful analogue of the terminal's `^^^^`, and it
    survives a reader who can't tell the fill from the text around it. */
 .ex-hit {
-  background: var(--bad-soft);
-  box-shadow: inset 0 -2px 0 var(--bad);
+  background: var(--fail-fill);
+  box-shadow: inset 0 -2px 0 var(--fail);
   color: var(--ink);
 }
-.is-warning .ex-hit { background: var(--warn-soft); box-shadow: inset 0 -2px 0 var(--warn); }
-.ex-ctx { background: var(--hover-row); }
+.is-warning .ex-hit { background: var(--warn-fill); box-shadow: inset 0 -2px 0 var(--warn); }
+.ex-ctx { background: var(--accent1-wash); }
 .ex-fold .ex-num { color: var(--ink-faint); }
 
 .suggestion-diff .title {
@@ -272,89 +361,80 @@ code.tick {
   color: var(--accent1);
   padding: 0 12px 6px;
 }
-.diff-del .ex-text { background: var(--bad-soft); }
-.diff-add .ex-text { background: var(--good-soft); }
+.diff-del .ex-text { background: var(--fail-fill); }
+.diff-add .ex-text { background: var(--ok-fill); }
 .diff-del .ex-num, .diff-add .ex-num { color: var(--ink-faint); }
 
 /* ---- Failed rows --------------------------------------------------------*/
 
-.failed-rows-card .head { display: flex; align-items: baseline; gap: 10px; margin: 14px 0 0; }
-.failed-rows-card .head h3 { font-size: var(--text-base); font-weight: 650; margin: 0; }
-.failed-rows-card .cap { font-weight: 400; }
+.failed-rows-card h2 {margin-block-end: 0}
+.failed-rows-card .summary p {
+  margin-top: 0;
+}
 .failed-rows-card .note, .rows-note {
   color: var(--ink-soft);
   font-size: var(--text-sm);
   margin: 8px 0 0;
 }
 
-/* The wrap scrolls; at ~1.94em a row (text-sm, 3px padding, grid line) it
-   shows ten rows under the sticky header. */
+/* The wrap is framed and scrolled like the checks table's `.tlist-wrap`, sized
+   with it by the shared rule above. The scrollport hugs the table, so rounding
+   it rounds the frame — and clips all four corners even mid-scroll, which a
+   radius on the corner cells could not do. */
 .row-table {
   overflow: auto;
   max-height: 21.5em;
   margin: 12px 0 0;
-  /* The scrollport hugs the table, so rounding it rounds the grid — and clips
-     all four corners even mid-scroll, which a radius on the corner cells could
-     not do. A cell radius is undefined under `border-collapse: collapse`. */
-  width: max-content;
-  max-width: 100%;
-  border-radius: 6px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
 }
-/* The table takes the width its columns need; the wrap scrolls when that is
-   more than there is room for. */
-.row-table table { border-collapse: collapse; font-size: var(--text-sm); }
-.row-table th, .row-table td {
-  border: 1px solid var(--row-line);
-  padding: 3px 10px;
-  text-align: left;
-}
-/* A table of a few columns has no width to spare its content, so its cells take
-   more of it. Counted rather than measured: the scrollport is sized by the table,
-   so it can't be asked how wide it came out. A wide table keeps the tighter
-   padding, which is what lets more of it fit before scrolling. */
-.row-table table:not(:has(thead th:nth-child(4))) :is(th, td) {
-  padding-left: 16px;
-  padding-right: 16px;
-}
-/* A wide table scrolls sideways; a long value clips rather than wraps. The data
-   sits on its own surface, a step above the page the block no longer frames it
-   against — `.bad` outranks this, so a blamed cell keeps its tint. */
-.row-table td {
-  white-space: nowrap;
-  max-width: 24em;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  background: light-dark(#ffffff, var(--paper));
-}
+.row-table table { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
+/* The head matches `.tlist thead th`. */
 .row-table th {
   position: sticky;
   top: 0;
   z-index: 1;
   /* Opaque, so scrolled rows never peek through from behind the header. */
-  background: color-mix(in oklab, var(--ink) 6%, var(--paper));
-  background-clip: padding-box;
-  /* Border-collapse would leave the header's top border at the table's edge;
-     a shadow on the sticky cells scrolls with them. */
-  box-shadow: inset 0 1px 0 var(--row-line);
-  font-family: var(--font-mono);
-  font-weight: 700;
-  color: var(--ink-soft);
+  background: var(--surface-1);
+  text-align: left;
+  padding: 6px 10px;
   white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  letter-spacing: .08em;
+  color: var(--ink-soft);
+  border-bottom: 1px solid var(--line);
+}
+/* A wide table scrolls sideways; a long value clips rather than wraps. The data
+   sits on its own surface, a step above the paper the panel no longer contrasts
+   it against — `.bad` outranks this, so a blamed cell keeps its tint. */
+.row-table td {
+  padding: 6px 10px;
+  text-align: left;
+  white-space: nowrap;
+  max-width: 24em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  background: var(--surface-2);
+  border-bottom: 1px solid var(--line-soft);
 }
 /* The seam between the primary key and the values the check is about. */
-.row-table .val-start { border-left: 4px solid var(--rule); }
+.row-table .val-start { border-left: 4px solid var(--line); }
 .row-table td.num { text-align: right; font-variant-numeric: tabular-nums; }
 /* A cell a problem blames; the tooltip says why. */
-.row-table td.bad { background: var(--bad-soft); cursor: default; }
+.row-table td.bad { background: var(--fail-fill); cursor: default; }
 .rownum { font-family: var(--font-mono); font-variant-numeric: tabular-nums; color: var(--ink-faint); text-align: right; }
-/* The codes a row broke, beside its number rather than out among the values. */
-.row-table .row-checks { white-space: nowrap; width: 1%; }
-.row-table td.row-checks .code-chip { cursor: default; }
-.row-table td.row-checks .code-chip + .code-chip { margin-left: 6px; }
+
 /* A missing value is not the string "null", so it stands out in red. */
-.row-table .is-null { color: var(--bad); }
+.row-table .is-null { color: var(--fail); }
 .row-table .is-absent { color: var(--ink-faint); }
 
 @media (max-width: 720px) {
   .step-meter { display: none; }
+  /* Too narrow for a column of tabs: they stack above the page instead. */
+  .report-body { flex-direction: column; }
+  .sidebar { position: static; width: auto; flex-direction: row; flex-wrap: wrap; }
+  /* Stacked, the pills row sits above the page, which runs edge to edge. */
+  .report-main { border-radius: 0; }
 }

--- a/crates/data-dict-cli/render/report/report.css
+++ b/crates/data-dict-cli/render/report/report.css
@@ -3,23 +3,18 @@
    modal primitives in tables.css, and is concatenated after both so its
    narrower rules win at equal specificity. */
 
+h2 {
+  font-size: var(--text-lg);
+  font-weight: 650;
+  margin: 0;
+}
+
 /* ---- Sections -----------------------------------------------------------*/
 
 .rsection { margin: 0 0 30px; }
-.rsection > h2 {
-  font-size: var(--text-lg);
-  font-weight: 650;
-  margin: 0 0 12px;
-}
 .rsection-note { color: var(--ink-soft); font-size: var(--text-sm); margin: 0 0 12px; }
-.rsection-title {
-  font-family: var(--font-mono);
-  font-size: var(--text-xl);
-  font-weight: 650;
-  margin: 0 0 18px;
-}
-/* A count trailing a heading — a table's rows, a card's failures — small and
-   quiet in the page's sans. */
+/* A count trailing a heading — a card's failures, a roster's checks — small
+   and quiet in the page's sans. */
 .row-total {
   font-family: var(--font-sans);
   font-size: var(--text-sm);
@@ -37,7 +32,7 @@
    cells still, so pointing changes nothing. The group selector is the one that
    covers the pointed-at row too. */
 .steps tbody.tgroup:hover td { background: var(--surface-2); }
-.steps th { white-space: nowrap; }
+.steps th { white-space: nowrap; background: var(--surface-0);}
 
 /* The grid the summary and the detail tables share: fixed layout, so every
    table on the page draws the same column edges, and long content clips
@@ -214,7 +209,6 @@ main:has(.report-body) .pagehead { padding: 0 28px; }
 /* A table hugs its content rather than stretching to the measure; `.rcontent`
    owns the cap, so the wrap only has to not outrun it. */
 .report-main .tlist-wrap, .row-table { width: fit-content; max-width: 100%; }
-.checks-head h2 { margin: 0; }
 .checks-tools { 
   display: flex; 
   align-items: center; 
@@ -238,11 +232,7 @@ main:has(.report-body) .pagehead { padding: 0 28px; }
    step's summary, a table of failed rows. */
 
 .problem-card, .step-summary {
-  border: 1px solid var(--line);
-  border-radius: 10px;
-  background: var(--surface-1);
-  padding: 16px 18px;
-  margin: 0 0 16px;
+  padding: 16px 0;
 }
 
 /* The failed rows are a block rather than a card: the table rules its own cells,
@@ -251,27 +241,18 @@ main:has(.report-body) .pagehead { padding: 0 28px; }
 .failed-rows-card { margin: 0 0 16px; }
 
 /* The step page's title block: the h1 names the target beside its verdict
-   square; the line below says what was checked. */
+   square. */
 /* The way back centres on the title's own line. Left inline, the link is placed
    by baseline — its box bottom on the text's baseline — which rides above the
    line's centre. */
 .step-title h1 { display: flex; align-items: center; }
 .step-title .target { font-family: var(--font-mono); font-size: 0.8em; }
-.step-title .sub { margin: 3px 0 0; color: var(--ink-soft); font-size: var(--text-lg); }
 
-/* The step page's summary card: the row counts and the failure meter on one
-   line, with the dictionary excerpt behind an expando below. */
-.step-summary .counts { display: flex; align-items: center; gap: 14px; }
-.step-summary .meta {
-  color: var(--ink-soft);
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-}
+/* The step page's summary card: the dictionary excerpt behind an expando. */
 .step-summary details summary {
   cursor: pointer;
   color: var(--ink-soft);
   font-size: var(--text-sm);
-  margin-top: 8px;
 }
 
 .problem-card .head {
@@ -395,7 +376,7 @@ code.tick {
   top: 0;
   z-index: 1;
   /* Opaque, so scrolled rows never peek through from behind the header. */
-  background: var(--surface-1);
+  background: var(--surface-0);
   text-align: left;
   padding: 6px 10px;
   white-space: nowrap;

--- a/crates/data-dict-cli/render/report/report.js
+++ b/crates/data-dict-cli/render/report/report.js
@@ -1,10 +1,11 @@
-// The validation report page: what the run checked, what it found, and one
-// finding in full. The report document rendered for a person — it adds nothing
-// to the document and withholds everything the document withholds.
+// The validation report page: one page per table, chosen from the sidebar, with
+// one check in full behind it. The report document rendered for a person — it
+// adds nothing to the document and withholds everything the document withholds.
 //
-// This file holds the app root: the verdict, the pages, and the reading
-// helpers both pages and the roster share. The roster lives in steps.js, the
-// problems list in problems.js, and one problem in full in diagnostic.js.
+// This file holds the app root: the verdict, the sidebar, the pages, and the
+// reading helpers both pages and the checks table share. The checks table lives
+// in steps.js, the problems list in problems.js, and one problem in full in
+// diagnostic.js.
 
 const BASE_TITLE = "Validation report";
 
@@ -17,7 +18,7 @@ const VERDICTS = {
   error: "Validation failed",
 };
 
-/* The verdict as a square, the same mark the summary and the detail tables
+/* The verdict as a square, the same mark the sidebar and the checks table
    use. */
 const VERDICT_SQUARE = { ok: "pass", warning: "warn", error: "fail" };
 
@@ -69,22 +70,61 @@ function tableOrder(steps) {
   return seen;
 }
 
+/* A table's verdict as one square: red if any of its checks failed or any
+   problem names it in error, green otherwise. The sidebar's only states are
+   these two — a table nothing could be said about is red, since silence there
+   is itself a finding (its source could not be read). */
+function tableVerdict(table) {
+  const failed = REPORT.steps.some(
+    (step) => step.table === table && step.outcome === "fail",
+  );
+  const errored = REPORT.problems.some(
+    (problem) => problem.table === table && problem.severity === "error",
+  );
+  return failed || errored ? "fail" : "pass";
+}
+
+/* The tables the sidebar lists: those the run's steps name, then any only its
+   problems or failed rows name. */
+const TABLES = (() => {
+  const seen = tableOrder(REPORT.steps);
+  for (const problem of REPORT.problems) {
+    if (problem.table && !seen.includes(problem.table)) seen.push(problem.table);
+  }
+  for (const entry of REPORT.failed_rows || []) {
+    if (!seen.includes(entry.table)) seen.push(entry.table);
+  }
+  return seen;
+})();
+
+/* The page a bare `report.html` opens on: the first table with a problem, since
+   that is what a reader came for, else the first table. */
+const DEFAULT_TABLE =
+  (TABLES.find((table) => tableVerdict(table) === "fail") || TABLES[0]) ?? null;
+
+function tableHash(table) {
+  return `#table/${encodeURIComponent(table)}`;
+}
+
 /* ---- Pages --------------------------------------------------------------- */
 
-function BackLink({ label }) {
-  return html`<a class="homelink" href="#" onClick=${(e) => { e.preventDefault(); goHome(); }}>
+/* Back to a table's page, or to the report's default page when the finding
+   names no table. */
+function BackLink({ table, label }) {
+  const home = table ? () => go(tableHash(table)) : goHome;
+  return html`<a class="homelink" href="#" onClick=${(e) => { e.preventDefault(); home(); }}>
     <span class="chev"><${Icon} svg=${ICONS.back} /></span><span>${label}</span></a>`;
 }
 
 /* The step page's title block: the h1 names the target beside its verdict
-   square and carries the way back to the report in its chevron; the line
+   square and carries the way back to its table in its chevron; the line
    below says what was checked, in the author's words where they wrote them. */
 function StepTitle({ step }) {
   const columns = step.columns || [];
   const target = step.table + (columns.length ? `.${columns.join(", ")}` : "");
   return html`<div class="step-title">
-    <h1><a class="homelink" href="#" title="Back to the report"
-        onClick=${(e) => { e.preventDefault(); goHome(); }}
+    <h1><a class="homelink" href="#" title="Back to ${step.table}"
+        onClick=${(e) => { e.preventDefault(); go(tableHash(step.table)); }}
       ><span class="chev"><${Icon} svg=${ICONS.back} /></span></a
       ><span class="sqname"><${VerdictSquare} outcome=${step.outcome} /><span class="target">${target}</span></span></h1>
     <p class="sub">${stepLabel(step)}</p>
@@ -131,30 +171,64 @@ function ProblemPage({ index }) {
   </section>`;
 }
 
-/* One dataset's failed rows with every column, gathered into the report's
-   `failed_rows` at validation time. */
-function FailedRowsPage({ table }) {
+/* Everything the run has to say about one table: its checks, the problems that
+   belong to no check, and its failed rows. The checks are the data-level steps
+   only; the metadata findings sit below them, since they are why checks went
+   unevaluated rather than checks themselves. */
+function TablePage({ table }) {
+  const problems = REPORT.problems.filter((p) => p.table === table && p.step == null);
   const entry = (REPORT.failed_rows || []).find((e) => e.table === table);
-  if (!entry) return html`<p class="rsection-note">No failed rows.</p>`;
-  const failures = cellFailures(REPORT.problems.filter((p) => p.table === table));
-  return html`<section class="rsection">
-    <h2 class="rsection-title">${table}</h2>
-    <${FailedRowsCard} rows=${entry.rows} keys=${entry.keys} values=${entry.values}
-      count=${entry.count} redacted=${entry.redacted} severity="error" failures=${failures} />
-  </section>`;
+  const failures = entry
+    ? cellFailures(REPORT.problems.filter((p) => p.table === table))
+    : null;
+  const counts = tableRowCounts(table);
+  return html`<div>
+    <h2 class="rsection-title"><span class="sqname"
+      ><${VerdictSquare} outcome=${tableVerdict(table)} /><span>${table}</span></span>
+      ${counts && html`<span class="row-total">(${fmtNum(counts.total)} rows)</span>`}</h2>
+    <${ChecksTable} table=${table} />
+    ${problems.length ? html`<section class="rsection">
+      <h2>Problems</h2>
+      ${problems.map((problem) => html`<${ProblemCard} key=${problem.index}
+        problem=${problem} showStep=${true} />`)}
+    </section>` : null}
+    ${entry ? html`
+      <${FailedRowsCard} rows=${entry.rows} keys=${entry.keys} values=${entry.values}
+        count=${entry.count} redacted=${entry.redacted} severity="error" failures=${failures} />` : null}
+  </div>`;
 }
 
-/* Everything the run has to say about one table, or one check. Both are the join
-   the report leaves to its consumer, drawn as a page. */
-function FilteredPage({ title, steps, problems }) {
-  return html`<div>
-    <h2 class="rsection-title">${title}</h2>
-    ${steps.length ? html`<${ChecksCard} steps=${steps} />` : null}
-    ${problems.length ? html`<${ProblemsCard} problems=${problems} />` : null}
-    ${!steps.length && !problems.length
-      ? html`<p class="rsection-note">Nothing to show.</p>`
-      : null}
-  </div>`;
+/* ---- The sidebar ----------------------------------------------------------
+   One tab per table: its name and its verdict square, the failed against the
+   total rows beneath, the active table marked. The tabs are the report's table
+   of contents, so they stay on screen while a table's page scrolls. */
+
+/* A table's rows as the run weighed them: the failed rows it counted (each
+   counted once, however many checks it broke) against the table's rows, the
+   most any step of it checked. Nothing to say when no step counted rows. */
+function tableRowCounts(table) {
+  let total = null;
+  for (const step of REPORT.steps) {
+    if (step.table === table && step.row_count != null) {
+      total = Math.max(total ?? 0, step.row_count);
+    }
+  }
+  if (total == null) return null;
+  const entry = (REPORT.failed_rows || []).find((e) => e.table === table);
+  return { failed: entry ? entry.count : 0, total };
+}
+
+function Sidebar({ active }) {
+  return html`<nav class="sidebar">
+    ${TABLES.map((table) => {
+      const counts = tableRowCounts(table);
+      return html`<a key=${table}
+        class=${table === active ? "active" : null}
+        href=${tableHash(table)}
+        ><span class="sqname"><${VerdictSquare} outcome=${tableVerdict(table)} /><span class="side-name">${table}</span></span>
+        ${counts && html`<span class="side-count">(${fmtNum(counts.failed)} / ${fmtNum(counts.total)})</span>`}</a>`;
+    })}
+  </nav>`;
 }
 
 /* ---- The app ------------------------------------------------------------- */
@@ -162,35 +236,49 @@ function FilteredPage({ title, steps, problems }) {
 function App() {
   const route = useRoute();
 
+  /* The old failed-rows page moved onto the table's page; send its links
+     there. */
+  const moved = route && route.view === "rows";
   useEffect(() => {
-    document.title = route ? `${route.key} — ${BASE_TITLE}` : BASE_TITLE;
+    if (moved) go(tableHash(route.key));
+  }, [moved, route && route.key]);
+
+  /* A table route names its table; no route opens the default table's page
+     without rewriting the address bar. */
+  const table = route && route.view === "table" ? route.key : !route ? DEFAULT_TABLE : null;
+
+  /* The table a detail page belongs to, so the sidebar can mark it. */
+  const storyStep = route && route.view === "step" ? stepsById.get(Number(route.key)) : null;
+  const storyProblem = route && route.view === "problem" ? REPORT.problems[Number(route.key)] : null;
+  const active = table ?? (storyStep && storyStep.table) ?? (storyProblem && storyProblem.table) ?? null;
+
+  useEffect(() => {
+    document.title = table ? `${table} — ${BASE_TITLE}` : BASE_TITLE;
+  }, [table]);
+
+  /* Escape leaves a detail view for the table it belongs to. */
+  useEffect(() => {
+    if (storyStep) return onEscape(20, () => (go(tableHash(storyStep.table)), true));
+    if (storyProblem && storyProblem.table) {
+      return onEscape(20, () => (go(tableHash(storyProblem.table)), true));
+    }
+    if (route && route.view === "problem") return onEscape(20, () => (goHome(), true));
   }, [route]);
 
-  /* Escape leaves a detail view, at the ladder's page priority. */
-  useEffect(() => (route ? onEscape(20, () => (goHome(), true)) : undefined), [route]);
-
-  /* A step page's h1 is the step's own story; every other detail page keeps
-     the way back as its heading. */
-  const storyStep = route && route.view === "step" ? stepsById.get(Number(route.key)) : null;
-
   let body;
-  if (!route) {
-    body = html`<div>
-      <${DatasetsCard} steps=${REPORT.steps} />
-      ${REPORT.steps.length ? html`<${ChecksCard} steps=${REPORT.steps} />` : null}
-    </div>`;
-  } else if (route.view === "step") {
+  if (table) {
+    body = html`<${TablePage} table=${table} />`;
+  } else if (route && route.view === "step") {
     body = html`<${StepPage} id=${route.key} />`;
-  } else if (route.view === "problem") {
+  } else if (route && route.view === "problem") {
     body = html`<${ProblemPage} index=${route.key} />`;
-  } else if (route.view === "rows") {
-    body = html`<${FailedRowsPage} table=${route.key} />`;
-  } else if (route.view === "table") {
-    body = html`<${FilteredPage} title=${route.key}
-      steps=${REPORT.steps.filter((s) => s.table === route.key)}
-      problems=${REPORT.problems.filter((p) => p.table === route.key)} />`;
-  } else {
+  } else if (moved) {
+    body = null;
+  } else if (route) {
     body = html`<p class="rsection-note">No such view.</p>`;
+  } else {
+    /* No tables at all: the run's problems are all it has to show. */
+    body = html`<${ProblemsCard} problems=${REPORT.problems} />`;
   }
 
   return html`<div>
@@ -198,13 +286,16 @@ function App() {
       <div class="head-title">
         ${storyStep
           ? html`<${StepTitle} step=${storyStep} />`
-          : html`<h1>${!route
-            ? html`<span class="sqname"><${VerdictSquare} outcome=${VERDICT_SQUARE[REPORT.status]} />${VERDICTS[REPORT.status]}</span>`
-            : html`<${BackLink} label=${BASE_TITLE} />`}</h1>`}
+          : html`<h1>${route && route.view === "problem"
+            ? html`<${BackLink} table=${active} label=${BASE_TITLE} />`
+            : html`<span class="sqname"><${VerdictSquare} outcome=${VERDICT_SQUARE[REPORT.status]} />${VERDICTS[REPORT.status]}</span>`}</h1>`}
       </div>
       <div class="head-actions"><${ThemeToggle} /></div>
     </header>
-    ${body}
+    <div class="report-body">
+      <${Sidebar} active=${active} />
+      <div class="report-main"><div class="rcontent">${body}</div></div>
+    </div>
   </div>`;
 }
 

--- a/crates/data-dict-cli/render/report/report.js
+++ b/crates/data-dict-cli/render/report/report.js
@@ -116,9 +116,8 @@ function BackLink({ table, label }) {
     <span class="chev"><${Icon} svg=${ICONS.back} /></span><span>${label}</span></a>`;
 }
 
-/* The step page's title block: the h1 names the target beside its verdict
-   square and carries the way back to its table in its chevron; the line
-   below says what was checked, in the author's words where they wrote them. */
+/* The step page's title block: the h1 names the target beside the check's
+   verdict square and carries the way back to the table's page in its chevron. */
 function StepTitle({ step }) {
   const columns = step.columns || [];
   const target = step.table + (columns.length ? `.${columns.join(", ")}` : "");
@@ -127,7 +126,6 @@ function StepTitle({ step }) {
         onClick=${(e) => { e.preventDefault(); go(tableHash(step.table)); }}
       ><span class="chev"><${Icon} svg=${ICONS.back} /></span></a
       ><span class="sqname"><${VerdictSquare} outcome=${step.outcome} /><span class="target">${target}</span></span></h1>
-    <p class="sub">${stepLabel(step)}</p>
   </div>`;
 }
 
@@ -144,18 +142,14 @@ function StepPage({ id }) {
   const location = located ? located.location : step.location;
   const context = located ? located.context : step.context;
   return html`<section class="rsection">
-    <article class="step-summary${problems[0] ? ` is-${problems[0].severity}` : ""}">
-      <div class="counts">
-        <span class="meta">${step.row_count != null
-          ? `${fmtNum(step.row_count)} rows checked, ${fmtNum(step.failed_row_count || 0)} failed`
-          : "no rows counted"}</span>
-        <${StepMeter} rows=${step.row_count} failed=${step.failed_row_count || 0} />
-      </div>
-      ${location ? html`<details>
+    <h2>${stepLabel(step)}${step.row_count != null && html`<span class="row-total"
+      >(${fmtNum(step.failed_row_count || 0)} / ${fmtNum(step.row_count)} rows failed)</span>`}</h2>
+    ${location ? html`<section class="step-summary${problems[0] ? ` is-${problems[0].severity}` : ""}">
+      <details>
         <summary>Constraint declaration</summary>
         <${YamlExcerpt} location=${location} context=${context} />
-      </details>` : null}
-    </article>
+      </details>
+    </section>` : null}
     ${problems.map((problem) => html`<${preact.Fragment} key=${problem.index}>
       <${OffendingRows} problem=${problem} />
       <${RowsNote} problem=${problem} />
@@ -181,11 +175,7 @@ function TablePage({ table }) {
   const failures = entry
     ? cellFailures(REPORT.problems.filter((p) => p.table === table))
     : null;
-  const counts = tableRowCounts(table);
   return html`<div>
-    <h2 class="rsection-title"><span class="sqname"
-      ><${VerdictSquare} outcome=${tableVerdict(table)} /><span>${table}</span></span>
-      ${counts && html`<span class="row-total">(${fmtNum(counts.total)} rows)</span>`}</h2>
     <${ChecksTable} table=${table} />
     ${problems.length ? html`<section class="rsection">
       <h2>Problems</h2>
@@ -286,7 +276,9 @@ function App() {
       <div class="head-title">
         ${storyStep
           ? html`<${StepTitle} step=${storyStep} />`
-          : html`<h1>${route && route.view === "problem"
+          : table
+            ? html`<h1><span class="sqname"><${VerdictSquare} outcome=${tableVerdict(table)} /><span>${table}</span></span></h1>`
+            : html`<h1>${route && route.view === "problem"
             ? html`<${BackLink} table=${active} label=${BASE_TITLE} />`
             : html`<span class="sqname"><${VerdictSquare} outcome=${VERDICT_SQUARE[REPORT.status]} />${VERDICTS[REPORT.status]}</span>`}</h1>`}
       </div>

--- a/crates/data-dict-cli/render/report/rows.js
+++ b/crates/data-dict-cli/render/report/rows.js
@@ -77,53 +77,21 @@ function cellFailures(problems) {
   return byCell;
 }
 
-/* Why a cell failed, for its tooltip: one head and constraint per problem
-   that names the cell — the author's own description where they wrote one,
-   the check's name where they didn't. */
-function cellTip(problems, column) {
+/* Why a cell failed, for its tooltip: one line per problem that names the
+   cell, styled as the checks table styles a check — the author's description
+   (or the check's name), the code quiet in parentheses. */
+function cellTip(problems) {
   const box = el("div");
   for (const problem of problems) {
     const step = problem.step != null ? stepsById.get(problem.step) : null;
-    box.appendChild(tipHead(`${problem.code} · ${column}`));
-    box.appendChild(el("p", null, step ? stepLabel(step) : checkName(problem.code)));
-  }
-  return box;
-}
-
-/* The checks a row broke, one entry per code. A row can say why it is here
-   without the reader hunting for the shaded cell, which on a wide table may be
-   scrolled out of sight. */
-function rowChecks(failures, row) {
-  const columns = failures && failures.get(row);
-  if (!columns) return [];
-  const byCode = new Map();
-  for (const problems of columns.values()) {
-    for (const problem of problems) {
-      if (!byCode.has(problem.code)) byCode.set(problem.code, new Set());
-      byCode.get(problem.code).add(problem);
-    }
-  }
-  return [...byCode.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([code, problems]) => ({ code, problems: [...problems] }));
-}
-
-/* What a code in the row's own column stands for. */
-function checkTip(problems) {
-  const box = el("div");
-  for (const problem of problems) {
-    const step = problem.step != null ? stepsById.get(problem.step) : null;
-    box.appendChild(tipHead(problem.code));
-    box.appendChild(el("p", null, step ? stepLabel(step) : checkName(problem.code)));
+    const line = el("p", "step-check", step ? stepLabel(step) : checkName(problem.code));
+    line.appendChild(el("span", "code", ` (${problem.code})`));
+    box.appendChild(line);
   }
   return box;
 }
 
 function RowTable({ rows, keys, values, failures }) {
-  /* The checks column earns its place only where the rows came from several of
-     them. A problem's own card lists rows that all broke the one check it is
-     about, so there the column would repeat a constant the card already states. */
-  const blame = !!failures;
   const keyCols = valueColumns(keys);
   const valCols = valueColumns(values);
   const columns = [...keyCols, ...valCols];
@@ -136,18 +104,15 @@ function RowTable({ rows, keys, values, failures }) {
   };
   return html`<div class="row-table">
     <table>
-      <thead><tr><th class="rownum">Row</th>${blame ? html`<th class="row-checks">Failed</th>` : null}${columns.map((c, j) => html`<th key=${c} class=${j === keyCols.length && j > 0 ? "val-start" : null}>${c}</th>`)}</tr></thead>
+      <thead><tr><th class="rownum"></th>${columns.map((c, j) => html`<th key=${c} class=${j === keyCols.length && j > 0 ? "val-start" : null}>${c}</th>`)}</tr></thead>
       <tbody>
         ${rows.map((row, i) => html`<tr key=${row}>
           <td class="rownum">${fmtNum(row)}</td>
-          ${blame ? html`<td class="row-checks">${rowChecks(failures, row).map((c) => html`<span key=${c.code}
-            class="code-chip" onMouseEnter=${(e) => showTip(checkTip(c.problems), e)}
-            onMouseMove=${moveTip} onMouseLeave=${hideTip}>${c.code}</span>`)}</td>` : null}
           ${columns.map((c, j) => {
             const blamed = failures && failures.get(row) && failures.get(row).get(c);
             return html`<td key=${c}
               class=${[formats[c].numeric ? "num" : null, j === keyCols.length && j > 0 ? "val-start" : null, blamed ? "bad" : null].filter(Boolean).join(" ") || null}
-              onMouseEnter=${blamed ? (e) => showTip(cellTip(blamed, c), e) : null}
+              onMouseEnter=${blamed ? (e) => showTip(cellTip(blamed), e) : null}
               onMouseMove=${blamed ? moveTip : null}
               onMouseLeave=${blamed ? hideTip : null}>
               <${Value} value=${cell(i, c)} format=${formats[c]} />
@@ -179,20 +144,22 @@ function RowsNote({ problem }) {
 /* A table of failed rows as its own card: the heading, the withheld badge and
    note, and the grid itself. A problem's card, an overflow's single row, and a
    dataset's failed-rows page are the same thing wearing different evidence. */
-function FailedRowsCard({ title = "Failed rows", rows, keys, values, count, redacted, severity, failures, note }) {
-  return html`<article class="failed-rows-card is-${severity}">
-    <div class="head">
-      <h3>${title}${count > rows.length &&
-        html` <span class="cap">(first ${fmtNum(rows.length)} out of ${fmtNum(count)})</span>`}</h3>
-      ${redacted && html`<span class="key restricted">values withheld</span>`}
-    </div>
+function FailedRowsCard({ rows, keys, values, count, redacted, severity, failures, note }) {
+  return html`<section class="failed-rows-card is-${severity}">
+    <h2>Failed rows${count != null && html`<span class="row-total"
+      >(${fmtNum(count)} ${count === 1 ? "failure" : "failures"}${count > rows.length
+        ? `, first ${fmtNum(rows.length)} shown`
+        : ""})</span>`}</h2>
+    ${redacted && html`<div class="summary">
+      <p><span class="key restricted">values withheld</span></p>
+    </div>`}
     <${RowTable} rows=${rows} keys=${keys} values=${values} failures=${failures} />
     ${redacted &&
       html`<p class="note">A column here is${" "}
         <code class="tick">display: restricted</code>, so its values are withheld.
         The row numbers are exact.</p>`}
     ${note && html`<p class="note">${note}</p>`}
-  </article>`;
+  </section>`;
 }
 
 /* The rows that broke a problem, as their own card. Dispatch is on what the

--- a/crates/data-dict-cli/render/report/steps.js
+++ b/crates/data-dict-cli/render/report/steps.js
@@ -153,7 +153,7 @@ function ChecksTable({ table }) {
       : "No data-level checks.";
   return html`<section class="rsection">
     <div class="checks-head">
-      <h2>Checks</h2>
+      <h2>Checks<span class="row-total">(${fmtNum(counts.fail)} / ${fmtNum(all.length)} checks failed)</span></h2>
       <div class="checks-tools">
         <input class="checks-filter" type="search" placeholder="Filter to a column…"
           value=${query} onInput=${(e) => setQuery(e.target.value)} />

--- a/crates/data-dict-cli/render/report/steps.js
+++ b/crates/data-dict-cli/render/report/steps.js
@@ -1,6 +1,6 @@
-/* The datasets summary and the per-dataset detail tables of the run's steps.
-   Rendered by report.js, which owns the reading helpers (stepCounts,
-   problemsByStep, tableOrder) this file uses. */
+/* One table's checks: the data-level steps it was validated against, sortable
+   and filterable. Rendered by report.js, which owns the reading helpers
+   (stepCounts, problemsByStep, tableOrder) this file uses. */
 
 /* What a step checked. An assertion names the columns it reads and carries its
    expression on the check itself, since the columns are what a reader scans
@@ -98,149 +98,43 @@ function VerdictSquare({ outcome }) {
 }
 
 /* Only a failed step links to its page — a passed or unevaluated step has
-   nothing actionable to show there. */
+   nothing actionable to show there. The link wears the check's name. */
 function StepRow({ step }) {
   const failed = step.failed_row_count;
   const evaluated = step.outcome !== "unevaluated";
   const href = step.outcome === "fail" ? `#step/${step.id}` : null;
-  return html`<tr data-href=${href}>
+  return html`<tr>
     <td>
-      <span class="sqname"><${VerdictSquare} outcome=${step.outcome} /><${StepCheck} step=${step} /></span>
+      <span class="sqname"><${VerdictSquare} outcome=${step.outcome} />${href
+        ? html`<a class="step-link" href=${href}><${StepCheck} step=${step} /></a>`
+        : html`<${StepCheck} step=${step} />`}</span>
     </td>
     <td><${StepTarget} step=${step} /></td>
-    <td class="num">${!evaluated || failed == null
-      ? "—"
-      : href && failed > 0
-        ? html`<a href=${href} title="Failed rows">${fmtNum(failed)}</a>`
-        : fmtNum(failed)}</td>
+    <td class="num">${!evaluated || failed == null ? "—" : fmtNum(failed)}</td>
     <td><${StepMeter} rows=${step.row_count} failed=${step.failed_row_count || 0} /></td>
   </tr>`;
 }
 
-/* The table's verdict as one bar: the rows its steps checked and failed,
-   summed, so the band weighs the table the way each row of the roster does. */
-function tableRows(steps) {
-  let rows = 0, failed = 0;
-  for (const step of steps) {
-    if (step.row_count == null) continue;
-    rows += step.row_count;
-    failed += step.failed_row_count || 0;
-  }
-  return { rows, failed };
-}
-
-/* A step row navigates to the step's page; a link or button inside it speaks
-   for itself. */
-function rowNav(e) {
-  if (e.target.closest("a, button")) return;
-  const tr = e.target.closest("tr[data-href]");
-  if (tr) go(tr.dataset.href);
-}
-
-/* Where a dataset's detail table sits on the page, so the summary can scroll
-   to it. */
-function datasetAnchor(table) {
-  return `ds-${table}`;
-}
-
-/* The data-level steps of one dataset. The summary and the detail tables both
-   weigh data-level checks only: the metadata checks a data run implies (a
-   column exists, a source is declared) are means, not findings. */
-function dataSteps(steps, table) {
-  return steps.filter((step) => step.table === table && !step.code.startsWith("M"));
-}
-
-/* The summary and the detail tables share one grid — same columns, same
-   widths — so a reader scanning down the page never loses the column edges.
-   The first column takes the width the others leave. */
+/* The table's fixed grid: long content clips rather than shifting the column
+   edges. The first column takes the width the others leave. */
 function ReportColGroup() {
   return html`<colgroup>
     <col /><col class="col-mid" /><col class="col-num" /><col class="col-meter" />
   </colgroup>`;
 }
 
-/* ---- The datasets summary ------------------------------------------------
-   One row per dataset the run covered, linked to its detail table below. */
-
-/* A dataset's verdict as one square: red if any of its checks failed, green
-   if at least one passed, and nothing when none reached a verdict. */
-function datasetSquare(counts) {
-  if (counts.fail) return "fail";
-  if (counts.pass) return "pass";
-  return "off";
-}
-
-/* The columns the summary can sort by. A dataset whose rows were never
-   counted sorts its failures last, rather than masquerading as zero. */
-const DATASET_SORTS = {
-  dataset: (row) => row.table,
-  checks: (row) => row.counts.fail,
-  failed: (row) => (row.counted ? row.failed : null),
-};
-
-function DatasetRow({ row }) {
-  const { table, steps, counts, counted, rows, failed } = row;
-  const scroll = () => {
-    const target = document.getElementById(datasetAnchor(table));
-    if (target) target.scrollIntoView();
-  };
-  /* The row scrolls to the dataset's own section in the roster below; the count
-     links past it to the failed rows, so it must not let the scroll fire too. */
-  const hasRows = (REPORT.failed_rows || []).some((e) => e.table === table);
-  const href = hasRows && failed > 0 ? `#rows/${encodeURIComponent(table)}` : null;
-  return html`<tr onClick=${scroll}>
-    <td><span class="sqname"><${VerdictSquare} outcome=${datasetSquare(counts)} /><span class="dataset-name">${table}</span></span></td>
-    <td class="num">${steps.length ? `${fmtNum(counts.fail)}/${fmtNum(steps.length)}` : "—"}</td>
-    <td class="num">${!counted ? "—" : href
-      ? html`<a href=${href} title="Failed rows"
-          onClick=${(e) => e.stopPropagation()}>${fmtNum(failed)}</a>`
-      : fmtNum(failed)}</td>
-    <td><${StepMeter} rows=${rows} failed=${failed} label="failures" /></td>
-  </tr>`;
-}
-
-function DatasetsCard({ steps }) {
+/* The data-level steps of one table. The metadata checks a data run implies
+   (a column exists, a source is declared) are means, not findings — the table
+   page shows them as problems instead. A table whose data could not be read
+   leaves every check of it unevaluated, so the reason is given once above the
+   table rather than repeated down every row. */
+function ChecksTable({ table }) {
   const [sort, setSort] = useState(null);
-  const tables = tableOrder(steps);
-  if (!tables.length) return null;
-  const rows = tables.map((table) => {
-    const dsteps = dataSteps(steps, table);
-    const { rows: rowCount, failed } = tableRows(dsteps);
-    return {
-      table,
-      steps: dsteps,
-      counts: stepCounts(dsteps),
-      counted: dsteps.some((step) => step.row_count != null),
-      rows: rowCount,
-      failed,
-    };
-  });
-  return html`<section class="rsection">
-    <h2>Datasets</h2>
-    <div class="tlist-wrap">
-      <table class="tlist datasets rtable">
-        <${ReportColGroup} />
-        <thead><tr>
-          <${SortHead} label="Dataset" sortKey="dataset" sort=${sort} onSort=${setSort} />
-          <${SortHead} label="Checks" sortKey="checks" sort=${sort} onSort=${setSort} numeric=${true} />
-          <${SortHead} label="Failures" sortKey="failed" sort=${sort} onSort=${setSort} numeric=${true} />
-          <th></th>
-        </tr></thead>
-        <tbody>
-          ${sortBy(rows, sort, DATASET_SORTS).map((row) => html`<${DatasetRow} key=${row.table} row=${row} />`)}
-        </tbody>
-      </table>
-    </div>
-  </section>`;
-}
-
-/* ---- The detail tables ---------------------------------------------------
-   Every dataset gets one, even one with no checks: an absent table would ask
-   the reader to notice a silence. A dataset whose data could not be read
-   leaves every check of it unevaluated, so the reason is given once under its
-   name rather than repeated down every row. */
-function DatasetSection({ table, steps, sort, onSort, query, failuresOnly }) {
-  const all = dataSteps(steps, table);
+  const [query, setQuery] = useState("");
+  const [failuresOnly, setFailuresOnly] = useState(false);
+  const all = REPORT.steps.filter(
+    (step) => step.table === table && !step.code.startsWith("M"),
+  );
   let shown = all;
   if (failuresOnly) shown = shown.filter((step) => step.outcome === "fail");
   if (query) {
@@ -250,15 +144,23 @@ function DatasetSection({ table, steps, sort, onSort, query, failuresOnly }) {
   }
   const counts = stepCounts(all);
   const unreadable = REPORT.problems.find(
-    (p) => p.table === table && (p.code === "M04" || p.code === "M05")
+    (p) => p.table === table && (p.code === "M04" || p.code === "M05"),
   );
   const note = query
     ? "No checks match."
     : all.length
       ? "No failures."
       : "No data-level checks.";
-  return html`<section class="rsection dataset-section" id=${datasetAnchor(table)}>
-    <h3>${table}</h3>
+  return html`<section class="rsection">
+    <div class="checks-head">
+      <h2>Checks</h2>
+      <div class="checks-tools">
+        <input class="checks-filter" type="search" placeholder="Filter to a column…"
+          value=${query} onInput=${(e) => setQuery(e.target.value)} />
+        <label class="checks-only"><input type="checkbox" checked=${failuresOnly}
+          onChange=${(e) => setFailuresOnly(e.target.checked)} /> Failures only</label>
+      </div>
+    </div>
     ${counts.unevaluated && unreadable
       ? html`<p class="rsection-note">${
           unreadable.code === "M04" ? "No source declared" : "Data could not be read"
@@ -269,33 +171,16 @@ function DatasetSection({ table, steps, sort, onSort, query, failuresOnly }) {
           <table class="tlist steps rtable">
             <${ReportColGroup} />
             <thead><tr>
-              <${SortHead} label="Check" sortKey="check" sort=${sort} onSort=${onSort} />
-              <${SortHead} label="Target" sortKey="target" sort=${sort} onSort=${onSort} />
-              <${SortHead} label="Failed rows" sortKey="failed" sort=${sort} onSort=${onSort} numeric=${true} />
+              <${SortHead} label="Check" sortKey="check" sort=${sort} onSort=${setSort} />
+              <${SortHead} label="Target" sortKey="target" sort=${sort} onSort=${setSort} />
+              <${SortHead} label="Failed rows" sortKey="failed" sort=${sort} onSort=${setSort} numeric=${true} />
               <th></th>
             </tr></thead>
-            <tbody class="tgroup" onClick=${rowNav}>
+            <tbody class="tgroup">
               ${sortBy(shown, sort, SORTS).map((step) => html`<${StepRow} key=${step.id} step=${step} />`)}
             </tbody>
           </table>
         </div>`
       : html`<p class="rsection-note">${note}</p>`}
-  </section>`;
-}
-
-function ChecksCard({ steps }) {
-  const [sort, setSort] = useState(null);
-  const [query, setQuery] = useState("");
-  const [failuresOnly, setFailuresOnly] = useState(false);
-  return html`<section class="rsection">
-    <h2>Checks</h2>
-    <div class="checks-tools">
-      <input class="checks-filter" type="search" placeholder="Filter to a column…"
-        value=${query} onInput=${(e) => setQuery(e.target.value)} />
-      <label class="checks-only"><input type="checkbox" checked=${failuresOnly}
-        onChange=${(e) => setFailuresOnly(e.target.checked)} /> Failures only</label>
-    </div>
-    ${tableOrder(steps).map((table) => html`<${DatasetSection} key=${table} table=${table}
-      steps=${steps} sort=${sort} onSort=${setSort} query=${query} failuresOnly=${failuresOnly} />`)}
   </section>`;
 }

--- a/crates/data-dict-cli/render/shared/app.css
+++ b/crates/data-dict-cli/render/shared/app.css
@@ -5,16 +5,36 @@
 :root {
   color-scheme: light dark;
 
+  /* ---- neutrals -------------------------------------------------------------
+     Three ladders, rung-numbered from recessed to raised. Surfaces climb from
+     the page to the float: a thing sits on the rung below its own. Ink fades
+     from the text to the whispers. Lines come in two strengths. A new neutral
+     belongs on one of these ladders, not in a component's own variable. */
+  /* Every surface is the base mixed with the ink. In light mode a higher rung
+     holds less ink (closer to white); in dark mode it holds more (closer to
+     the light ink) — so elevation reads the same way in both schemes, and one
+     base and one ink tune the whole ladder. */
+  --surface-base: light-dark(#ffffff, #0e1216);
+  --surface-0: light-dark( /* the page */
+    color-mix(in oklab, var(--ink) 6%, var(--surface-base)),
+    color-mix(in oklab, var(--ink) 3%, var(--surface-base)));
+  --surface-1: light-dark( /* panels and cards */
+    color-mix(in oklab, var(--ink) 2.5%, var(--surface-base)),
+    color-mix(in oklab, var(--ink) 6%, var(--surface-base)));
+  --surface-2: light-dark( /* table cells, wells */
+    color-mix(in oklab, var(--ink) 1%, var(--surface-base)),
+    color-mix(in oklab, var(--ink) 9%, var(--surface-base)));
+  --surface-3: light-dark( /* tooltip, search results, controls */
+    var(--surface-base),
+    color-mix(in oklab, var(--ink) 12%, var(--surface-base)));
+
   --ink: light-dark(#1c2430, #e3e6ea);
   --ink-soft: light-dark(#5b6675, #a3acb7);
   --ink-faint: light-dark(#66707e, #8d97a2);
-  --float: light-dark(#ffffff, #161b21); /* tooltip, search results, controls */
-  --rule: light-dark(#d6d0c4, #333b44);
-  --row-line: light-dark(#e4e0d7, #2a3138);
+  --ink-inverse: light-dark(#ffffff, #14142c); /* text on an accent1 fill */
 
-  /* The page background and the surface everthing sits on */
-  --background: light-dark(#f1eee8, #181d22);
-  --paper: light-dark(#f8f6f4, #0e1216);
+  --line: light-dark(#d6d0c4, #333b44); /* card borders, strong separators */
+  --line-soft: light-dark(#e4e0d7, #2a3138); /* in-table separators */
 
   /* ---- accents ------------------------------------------------------------
      Solarized's eight. Everything coloured on the page is one of them as it
@@ -42,37 +62,37 @@
   --accent1: light-dark(
     color-mix(in oklab, var(--accent1-hue) 80%, black),
     color-mix(in oklab, var(--accent1-hue) 80%, white));
-  --accent1-soft: light-dark(
+  --accent1-fill: light-dark(
     color-mix(in oklab, var(--accent1-hue) 20%, white),
-    color-mix(in oklab, var(--accent1-hue) 20%, var(--background)));
+    color-mix(in oklab, var(--accent1-hue) 20%, var(--surface-0)));
   /* a caveat rather than a fact, which is what the palette's yellow is for and
      what its three tenants have in common: an unresolved todo, a restricted
      column, and a validation warning */
   --warn: light-dark(
     color-mix(in oklab, var(--yellow) 80%, black),
     color-mix(in oklab, var(--yellow) 80%, white));
-  --warn-soft: light-dark(
+  --warn-fill: light-dark(
     color-mix(in oklab, var(--yellow) 20%, white),
-    color-mix(in oklab, var(--yellow) 20%, var(--background)));
+    color-mix(in oklab, var(--yellow) 20%, var(--surface-0)));
   /* a verdict: green passed, red failed. Only the validation report has
      verdicts to report, so only it uses these. */
-  --good: light-dark(
+  --ok: light-dark(
     color-mix(in oklab, var(--green) 80%, black),
     color-mix(in oklab, var(--green) 80%, white));
-  --good-soft: light-dark(
+  --ok-fill: light-dark(
     color-mix(in oklab, var(--green) 20%, white),
-    color-mix(in oklab, var(--green) 20%, var(--background)));
-  --bad: light-dark(
+    color-mix(in oklab, var(--green) 20%, var(--surface-0)));
+  --fail: light-dark(
     color-mix(in oklab, var(--red) 80%, black),
     color-mix(in oklab, var(--red) 80%, white));
-  --bad-soft: light-dark(
+  --fail-fill: light-dark(
     #f6e1d9,
-    color-mix(in oklab, var(--red) 20%, var(--background)));
+    color-mix(in oklab, var(--red) 20%, var(--surface-0)));
   /* every row that takes part in a relationship wears this, so it is the
      quietest step on the ladder */
-  --hover-row: light-dark(
+  --accent1-wash: light-dark(
     color-mix(in oklab, var(--accent1-hue) 10%, white),
-    color-mix(in oklab, var(--accent1-hue) 10%, var(--background)));
+    color-mix(in oklab, var(--accent1-hue) 10%, var(--surface-0)));
   --shadow-far: light-dark(rgba(28, 36, 48, 0.25), rgba(0, 0, 0, 0.5));
   --shadow-lift: light-dark(rgba(28, 36, 48, 0.45), rgba(0, 0, 0, 0.7));
 
@@ -80,7 +100,7 @@
   --chip: light-dark(#e9ecf2, #21262d);
   --link: var(--accent1); /* a link is the accent doing its plainest job */
   /* a bar is a mark rather than text or a fill, so it takes the raw value */
-  --fail-bar: var(--red);
+  --fail-mark: var(--red);
 
   /* The two faces everything on the page wears: sans for prose, mono for
      names, values, and micro-labels. */
@@ -105,7 +125,7 @@
 
 body {
   margin: 0;
-  background: var(--background);
+  background: var(--surface-0);
   color: var(--ink);
   font-family: var(--font-sans);
   font-size: var(--text-base);
@@ -145,8 +165,8 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
 .homelink:hover .chev { transform: translateX(-.1em); }
 .head-actions { display: flex; align-items: center; gap: 10px; }
 .icon-btn {
-  flex: none; width: 38px; height: 38px; border: 1px solid var(--rule); border-radius: 9px;
-  background: var(--paper); color: var(--ink); cursor: pointer;
+  flex: none; width: 38px; height: 38px; border: 1px solid var(--line); border-radius: 9px;
+  background: var(--surface-1); color: var(--ink); cursor: pointer;
   display: inline-flex; align-items: center; justify-content: center;
 }
 /* The key badges, worn identically by a column in the diagram's tables and by
@@ -157,11 +177,11 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
   font-weight: 700;
   letter-spacing: 0.04em;
   color: var(--accent1);
-  background: var(--accent1-soft);
+  background: var(--accent1-fill);
   border-radius: 3px;
   padding: 1px 4px;
 }
-.key.restricted { color: var(--warn); background: var(--warn-soft); }
+.key.restricted { color: var(--warn); background: var(--warn-fill); }
 
 .icon-btn:hover { border-color: var(--accent1); color: var(--accent1); }
 .icon-btn svg { display: block; width: 19px; height: 19px; }
@@ -180,8 +200,8 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
   z-index: 2000;
   max-width: 40ch;
   padding: 7px 9px;
-  background: var(--float);
-  border: 1px solid var(--rule);
+  background: var(--surface-3);
+  border: 1px solid var(--line);
   border-radius: 6px;
   box-shadow: 0 8px 24px -12px var(--shadow-lift);
   font-size: var(--row-text);
@@ -198,13 +218,16 @@ main { max-width: 1180px; margin: 0 auto; padding: 40px 44px 90px; }
   justify-content: space-between;
   gap: 12px;
   padding-bottom: 5px;
-  border-bottom: 1px solid var(--row-line);
+  border-bottom: 1px solid var(--line-soft);
   color: var(--ink);
 }
 #tip .tip-head code { color: var(--accent1); }
 /* the aside keeps its line; the code beside it is what wraps */
 #tip .tip-sub { color: var(--ink-faint); white-space: nowrap; }
 #tip p { margin: 0; color: var(--ink-soft); }
+#tip p + p { margin-top: 4px; }
+/* a check named as the checks table names it: description, code quiet after */
+#tip .code { color: var(--ink-faint); font-family: var(--font-mono); }
 #tip .tip-head + p { margin-top: 5px; }
 /* a second relationship behind the same chip, set off from the first */
 #tip .tip-head ~ .tip-head { margin-top: 9px; }

--- a/crates/data-dict-cli/render/shared/live.js
+++ b/crates/data-dict-cli/render/shared/live.js
@@ -11,13 +11,13 @@
     #${PANEL} {
       position: fixed; left: 14px; bottom: 14px; z-index: 2000;
       max-width: min(760px, calc(100vw - 28px)); max-height: 42vh; overflow: auto;
-      background: var(--float, #fff); color: var(--ink, #1c2430);
-      border: 1px solid var(--rule, #dfdcd5); border-left: 3px solid var(--edge);
+      background: var(--surface-3, #fff); color: var(--ink, #1c2430);
+      border: 1px solid var(--line, #dfdcd5); border-left: 3px solid var(--edge);
       border-radius: 8px; padding: 10px 14px 12px;
       box-shadow: 0 10px 30px var(--shadow-far, rgba(0,0,0,.25));
       font-size: 12px;
     }
-    #${PANEL}.err { --edge: var(--bad, #d80d0d); }
+    #${PANEL}.err { --edge: var(--fail, #d80d0d); }
     #${PANEL}.warn { --edge: var(--warn, #9d5d00); }
     #${PANEL}.off { --edge: var(--ink-faint, #98a2b0); }
     #${PANEL} .hd {

--- a/crates/data-dict-cli/render/shared/route.js
+++ b/crates/data-dict-cli/render/shared/route.js
@@ -22,6 +22,10 @@ function useRoute() {
     const follow = () => {
       hideTip();
       setRoute(parseHash());
+      /* A new page starts at its top. The hash only ever names a route, never
+         an in-page anchor, so the fragment scroll the browser just attempted
+         (a no-op — no element matches) is safe to override. */
+      scrollTo(0, 0);
     };
     addEventListener("hashchange", follow);
     return () => removeEventListener("hashchange", follow);

--- a/crates/data-dict-cli/render/shared/tables.css
+++ b/crates/data-dict-cli/render/shared/tables.css
@@ -5,21 +5,21 @@
    dict/tables.css. Shares the page palette in app.css. */
 
 .tlist-wrap {
-  border: 1px solid var(--rule); border-radius: 10px;
-  background: var(--paper); overflow-x: auto;
+  border: 1px solid var(--line); border-radius: 10px;
+  background: var(--surface-1); overflow-x: auto;
 }
 .tlist { width: 100%; border-collapse: collapse; font-size: var(--text-sm); }
 .tlist thead th {
   text-align: left; padding: 8px 14px; white-space: nowrap;
   font-family: var(--font-mono);
   font-size: var(--text-sm); font-weight: 700; letter-spacing: .08em; text-transform: uppercase;
-  color: var(--ink-soft); border-bottom: 1px solid var(--rule);
+  color: var(--ink-soft); border-bottom: 1px solid var(--line);
 }
 .tlist th.num, .tlist td.num { text-align: right; font-variant-numeric: tabular-nums; }
 .tlist td { padding: 0 14px; vertical-align: baseline; }
 
 /* one tbody per table: the block shares a border and a hover state */
-.tlist tbody.tgroup { border-bottom: 1px solid var(--rule); }
+.tlist tbody.tgroup { border-bottom: 1px solid var(--line); }
 .tlist tr[data-href] { cursor: pointer; }
 .tlist tbody.tgroup:last-child { border-bottom: none; }
 .tlist tbody.tgroup:hover td, .tlist tbody.tgroup:focus-within td { background: var(--chip); }
@@ -41,6 +41,6 @@ a.cpath:focus-visible { outline: 2px solid var(--link); outline-offset: 2px; }
    page's own text face. */
 .val {
   display: inline-block;
-  background: var(--paper); border: 1px solid var(--rule); border-radius: 4px;
+  background: var(--surface-1); border: 1px solid var(--line); border-radius: 4px;
   padding: 0 3px; color: var(--ink);
 }


### PR DESCRIPTION
- polish the validation report layout with anchored sidebar pills, a framed main panel, consistent content measure, table-level row counts, and streamlined failed-row presentation
- systematise the shared report palette with semantic surface, ink, line, and status tokens across light and dark modes
- make table and check page heading hierarchy consistent, with verdicts and relevant failure counts placed alongside their targets
- document `rg`-based repository exploration for subagents and add local guidance for the render-report UI structure, safety constraints, and testing
